### PR TITLE
Disables running the pre-commit action on main

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,8 +2,6 @@ name: pre-commit
 
 on:
   pull_request:
-  push:
-    branches: [main]
 
 jobs:
   pre-commit:


### PR DESCRIPTION
Pre-commit errors when CI runs on main, as one of the checks is to make sure we aren’t commiting to main.

So lets not run it there.