### PR TITLE
Upload test analytics to Codecov

### DIFF
--- a/.github/workflows/_build_image.yml
+++ b/.github/workflows/_build_image.yml
@@ -59,6 +59,11 @@ on:
         description: Upload coverage reports to Codecov
         required: false
         default: false
+      upload_tests:
+        type: boolean
+        description: Upload test results to Codecov
+        required: false
+        default: false
     secrets:
       DOCKER_USERNAME:
         description: Username for Docker Hub
@@ -130,6 +135,11 @@ on:
       upload_coverage:
         type: boolean
         description: Upload coverage reports to Codecov
+        required: false
+        default: false
+      upload_tests:
+        type: boolean
+        description: Upload test results to Codecov
         required: false
         default: false
 
@@ -215,11 +225,6 @@ jobs:
         run: |
             docker cp test-container:/home/ioos/coverage.xml ${{ inputs.working_directory }}/coverage.xml || true
 
-      - name: Clean up test container
-        if: ${{ inputs.test_command }}
-        run: |
-            docker rm test-container || true
-
       - name: Upload coverage to Codecov
         if: ${{ inputs.test_command && inputs.upload_coverage }}
         uses: codecov/codecov-action@v5
@@ -229,6 +234,22 @@ jobs:
         #   files: ./coverage.xml
         #   fail_ci_if_error: false
         #   verbose: true
+
+      - name: Extract test results
+        if: ${{ inputs.test_command && inputs.upload_tests }}
+        run: |
+            docker cp test-container:/home/ioos/junit.xml ${{ inputs.working_directory }}/junit.xml || true
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() && inputs.test_command && inputs.upload_tests }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Clean up test container
+        if: ${{ inputs.test_command }}
+        run: |
+            docker rm test-container || true
 
     #   - name: Test if Dagster can find jobs in repo
     #     if: ${{ inputs.test_dagster_jobs }}

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -76,9 +76,15 @@ jobs:
     - name: Run tests
       working-directory: ./common
       run: |
-        uv run pytest -vv --cov-report=xml
+        uv run pytest -vv --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
 
     - name: Upload coverage reports to Codecov with GitHub Action
       uses: codecov/codecov-action@v5
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pipeline_hohonu.yml
+++ b/.github/workflows/pipeline_hohonu.yml
@@ -25,8 +25,9 @@ jobs:
             image_name: buoy_retriever_hohonu
             image_tag: ${{ needs.shortsha.outputs.shortsha }}
             # push_image: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-            test_command: "pixi run pytest --cov=. --cov-report=xml --cov-report=term-missing"
+            test_command: "pixi run pytest --cov=. --cov-report=xml --cov-report=term-missing --junitxml=junit.xml -o junit_family=legacy"
             upload_coverage: true
+            upload_tests: true
 
     # deploy:
     #     needs: [shortsha, build_test_push]


### PR DESCRIPTION
It should help make it quicker to narrow in on failing tests.

See https://docs.codecov.com/docs/test-analytics

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #112 
- <kbd>&nbsp;1&nbsp;</kbd> #89 👈 
<!-- GitButler Footer Boundary Bottom -->

