### PR TITLE
Codecov Flags

### DIFF
--- a/.github/workflows/_build_image.yml
+++ b/.github/workflows/_build_image.yml
@@ -54,11 +54,11 @@ on:
         type: string
         description: Command to run tests inside the container, likely `pixi run pytest`
         required: false
-      upload_coverage:
-        type: boolean
-        description: Upload coverage reports to Codecov
+      coverage_flags:
+        type: string
+        description: Codecov flags to use when uploading coverage
         required: false
-        default: false
+        default: ""
       upload_tests:
         type: boolean
         description: Upload test results to Codecov
@@ -132,11 +132,11 @@ on:
         type: string
         description: Command to run tests inside the container, likely `pixi run pytest`
         required: false
-      upload_coverage:
-        type: boolean
-        description: Upload coverage reports to Codecov
+      coverage_flags:
+        type: string
+        description: Codecov flags to use when uploading coverage
         required: false
-        default: false
+        default: ""
       upload_tests:
         type: boolean
         description: Upload test results to Codecov
@@ -221,15 +221,17 @@ jobs:
             docker run --name test-container -e CI=true ${{ env.IMAGE_NAME }}:${{ env.DOCKER_TAG }} /bin/sh -c "${{ inputs.test_command }}"
 
       - name: Extract coverage data
-        if: ${{ inputs.test_command && inputs.upload_coverage }}
+        if: ${{ inputs.test_command && inputs.coverage_flags != '' }}
         run: |
             docker cp test-container:/home/ioos/coverage.xml ${{ inputs.working_directory }}/coverage.xml || true
 
       - name: Upload coverage to Codecov
-        if: ${{ inputs.test_command && inputs.upload_coverage }}
+        if: ${{ inputs.test_command && inputs.coverage_flags != '' }}
         uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          flags: ${{ inputs.coverage_flags }}
         # with:
         #   files: ./coverage.xml
         #   fail_ci_if_error: false

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -82,6 +82,8 @@ jobs:
       uses: codecov/codecov-action@v5
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      with:
+        flags: common
 
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}

--- a/.github/workflows/pipeline_hohonu.yml
+++ b/.github/workflows/pipeline_hohonu.yml
@@ -26,7 +26,7 @@ jobs:
             image_tag: ${{ needs.shortsha.outputs.shortsha }}
             # push_image: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
             test_command: "pixi run pytest --cov=. --cov-report=xml --cov-report=term-missing --junitxml=junit.xml -o junit_family=legacy"
-            upload_coverage: true
+            coverage_flags: hohonu
             upload_tests: true
 
     # deploy:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+# https://docs.codecov.com/docs/flags#recommended-automatic-flag-management
+flag_management:
+  default_rules: # the rules that will be followed for any flag added, generally
+    carryforward: true
+    statuses:
+      - type: project
+        target: auto
+        threshold: 1%
+      - type: patch
+        target: 90%


### PR DESCRIPTION
Uses [Codecov flags](https://docs.codecov.com/docs/flags) to help manage the different groups of tests and coverage results without erroring due to differing reports on every run.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #112 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #89 
<!-- GitButler Footer Boundary Bottom -->

