### PR TITLE
Postgres config updates

### DIFF
--- a/backend/buoy_retriever/settings.py
+++ b/backend/buoy_retriever/settings.py
@@ -139,6 +139,7 @@ DATABASES = {
         "PORT": int(os.environ.get("POSTGRES_PORT", 5432)),  # noqa: PLW1508
         "OPTIONS": {
             "sslmode": "prefer",
+            "options": f"-c search_path={os.environ.get("POSTGRES_SCHEMA", "public")}",
         },
     },
 }

--- a/backend/buoy_retriever/settings.py
+++ b/backend/buoy_retriever/settings.py
@@ -139,7 +139,7 @@ DATABASES = {
         "PORT": int(os.environ.get("POSTGRES_PORT", 5432)),  # noqa: PLW1508
         "OPTIONS": {
             "sslmode": "prefer",
-            "options": f"-c search_path={os.environ.get("POSTGRES_SCHEMA", "public")}",
+            "options": os.environ.get("POSTGRES_OPTIONS", ""),
         },
     },
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,6 +49,8 @@ services:
     environment:
       BACKEND_ENV: dev
       POSTGRES_HOST: db
+      # Allows for setting schema to something other than 'public'
+      POSTGRES_OPTIONS: "-c search_path=buoy_retriever"
       # CACHE_HOST: cache
       # QUEUE_HOST: queue
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,8 +9,8 @@ services:
       - "${BUOY_RETRIEVER_DB_PORT:-5432}:5432"
     env_file:
       - ./docker-data/secret.env
-    environment:
-      PGDATA: /var/lib/postgresql/data/PGDATA
+    # environment:
+    #   PGDATA: /var/lib/postgresql/data
     volumes:
       - dbdata:/var/lib/postgresql/data
     healthcheck:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,7 @@
+volumes:
+  dbdata:
+  django_static:
+
 services:
   db:
     image: timescale/timescaledb-ha:pg17-ts2.21@sha256:a2f4731fd341e93a96fdc49f21137db0ec27bd3d72a5dab241fec2b344f2f54c
@@ -8,7 +12,7 @@ services:
     environment:
       PGDATA: /var/lib/postgresql/data/PGDATA
     volumes:
-      - ./docker-data/postgres:/var/lib/postgresql/data:cached
+      - dbdata:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-buoy_retriever}"]
       interval: 2s
@@ -36,7 +40,7 @@ services:
       - ./backend:/home/uwsgi:cached
       - /home/uwsgi/.pixi
       - ./docker-data/media:/media:cached
-      - ./docker-data/static:/static:cached
+      - django_static:/static:rw
     ports:
       - "${BUOY_RETRIEVER_BACKEND_PORT:-8080}:8080"
     env_file:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
     #   PGDATA: /var/lib/postgresql/data
     volumes:
       - dbdata:/var/lib/postgresql/data
+      - ./docker-data/db/initdb.sh:/docker-entrypoint-initdb.d/initdb.sh:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-buoy_retriever}"]
       interval: 2s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     volumes:
       - ./docker-data/postgres:/var/lib/postgresql/data:cached
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-buoy_retriever}"]
       interval: 2s
       timeout: 5s
       retries: 5

--- a/docker-data/db/initdb.sh
+++ b/docker-data/db/initdb.sh
@@ -1,0 +1,11 @@
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" buoy_retriever <<EOF
+
+-- create the app schema
+CREATE SCHEMA buoy_retriever AUTHORIZATION buoy_retriever;
+
+-- Explicitly set the search path to prefer buoy_retriever schema
+ALTER ROLE buoy_retriever SET search_path TO "buoy_retriever";
+
+-- Revoke the default create grant for of any objects in public
+REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+EOF


### PR DESCRIPTION
Addresses the following:

*   Updates the Postgres `db` service health check to use the `POSTGRES_USER` env var rather than assume the Postgres owner's name is `postgres`.
*   Updates `docker-compose.yml` to use volumes for Postgres service rather than host directories (to resolve some directory ownership issues when developing locally).
*   Comment out the specific path for `PGDATA` in `db` service env var to avoid TSDB confusion in setup directory creation.
*   Allow for using a Postgres schema that is not the `public` schema, avoiding the default behavior of allowing `CREATE` privileges on the `public` schema, and then for Django to use the `public` schema. Requires the included `initdb.sh` script when starting a new Postgres database locally, as well as the `POSTGRES_OPTIONS="-c search_path=buoy_retriever"` env var to be set to override the default Postgres search path.