### PR TITLE
Docker image and pixi environment updates

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -32,13 +32,15 @@ COPY --chown=${USER}:${USER} ./pyproject.toml ./pixi.lock ${USER_HOME}
 RUN --mount=type=cache,id=br_pixi,target=${USER_HOME}/.cache/rattler/cache,uid=${USER_UID},gid=${USER_UID} \
     pixi install -e default --frozen --manifest-path ./pyproject.toml
 
-RUN pixi shell-hook -e default --shell bash | grep -vie "activate.d" | grep -vie "completion" > /support/shell-hook.sh \
-    && echo 'exec "$@"' >> /support/shell-hook.sh
+RUN echo '#!/bin/bash' > /support/shell-hook.sh \
+    && pixi shell-hook -e default --shell bash | grep -vie "activate.d" | grep -vie "completion" >> /support/shell-hook.sh \
+    && echo 'exec "$@"' >> /support/shell-hook.sh \
+    && chmod +x /support/shell-hook.sh
 
 ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-unknown}
 
-ENTRYPOINT ["/bin/bash", "/support/shell-hook.sh"]
+ENTRYPOINT ["/support/shell-hook.sh"]
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=20s \
     CMD /usr/bin/curl -D- -o /dev/null --silent --fail "http://localhost:8080/backend/health/"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/prefix-dev/pixi:0.55.0-noble@sha256:423daf63e4e876ab42b1be9ddee3fc867ba8b9fa511e0634de3b9df12ff1a90d AS base
+FROM ghcr.io/prefix-dev/pixi:0.66.0 AS base
 
 # Output logging faster
 ENV PYTHONUNBUFFERED=1
@@ -22,10 +22,10 @@ USER ${USER}
 WORKDIR ${USER_HOME}
 
 COPY --chown=${USER}:${USER} ./pyproject.toml ./pixi.lock ${USER_HOME}
-RUN --mount=type=cache,id=br_pixi,target=${USER_HOME}.cache/rattler/cache,uid=${USER_UID},gid=${USER_UID} \
-    pixi install -e default
+RUN --mount=type=cache,id=br_pixi,target=${USER_HOME}/.cache/rattler/cache,uid=${USER_UID},gid=${USER_UID} \
+    pixi install -e default --frozen --manifest-path ./pyproject.toml
 
-RUN pixi shell-hook -e default > /support/shell-hook.sh \
+RUN pixi shell-hook -e default --shell bash | grep -vie "activate.d" | grep -vie "completion" > /support/shell-hook.sh \
     && echo 'exec "$@"' >> /support/shell-hook.sh
 
 ARG IMAGE_TAG

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,10 +28,19 @@ RUN chown -R ${USER}:${USER} ${USER_HOME} /static /media /support ${APP_DIR} /op
 USER ${USER}
 WORKDIR ${APP_DIR}
 
+# Copy only env spec and build
 COPY --chown=${USER}:${USER} ./pyproject.toml ./pixi.lock ${APP_DIR}
 RUN --mount=type=cache,id=br_pixi,target=${USER_HOME}/.cache/rattler/cache,uid=${USER_UID},gid=${USER_UID} \
     pixi config set --global detached-environments "/opt/pixi/envs" \
     && pixi install -e default --frozen --manifest-path ./pyproject.toml
+
+# Copy app source (and only app source)
+COPY --chown=${USER}:${USER} ./manage.py ${APP_DIR}/
+COPY --chown=${USER}:${USER} ./account ${APP_DIR}/account
+COPY --chown=${USER}:${USER} ./buoy_retriever ${APP_DIR}/buoy_retriever
+COPY --chown=${USER}:${USER} ./datasets ${APP_DIR}/datasets
+COPY --chown=${USER}:${USER} ./pipelines ${APP_DIR}/pipelines
+COPY --chown=${USER}:${USER} ./src ${APP_DIR}/src
 
 RUN echo '#!/bin/bash' > /support/shell-hook.sh \
     && pixi shell-hook -e default --shell bash | grep -vie "activate.d" | grep -vie "completion" >> /support/shell-hook.sh \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,16 +21,16 @@ ENV PIXI_HOME="${USER_HOME}/.pixi"
 # Setup user
 RUN groupadd ${USER} \
     && useradd -rm -d ${USER_HOME} -s /bin/bash -g ${USER} -u ${USER_UID} ${USER}
-RUN mkdir -p "${USER_HOME}/app" /static /media /support
-RUN chown -R ${USER}:${USER} ${USER_HOME} /static /media /support
-
+RUN mkdir -p /static /media /support /opt/pixi/envs
+RUN chown -R ${USER}:${USER} ${USER_HOME} /static /media /support /opt/pixi/envs
 
 USER ${USER}
 WORKDIR ${USER_HOME}
 
 COPY --chown=${USER}:${USER} ./pyproject.toml ./pixi.lock ${USER_HOME}
 RUN --mount=type=cache,id=br_pixi,target=${USER_HOME}/.cache/rattler/cache,uid=${USER_UID},gid=${USER_UID} \
-    pixi install -e default --frozen --manifest-path ./pyproject.toml
+    pixi config set detached-environments "/opt/pixi/envs" \
+    && pixi install -e default --frozen --manifest-path ./pyproject.toml
 
 RUN echo '#!/bin/bash' > /support/shell-hook.sh \
     && pixi shell-hook -e default --shell bash | grep -vie "activate.d" | grep -vie "completion" >> /support/shell-hook.sh \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -40,7 +40,6 @@ COPY --chown=${USER}:${USER} ./account ${APP_DIR}/account
 COPY --chown=${USER}:${USER} ./buoy_retriever ${APP_DIR}/buoy_retriever
 COPY --chown=${USER}:${USER} ./datasets ${APP_DIR}/datasets
 COPY --chown=${USER}:${USER} ./pipelines ${APP_DIR}/pipelines
-COPY --chown=${USER}:${USER} ./src ${APP_DIR}/src
 
 RUN echo '#!/bin/bash' > /support/shell-hook.sh \
     && pixi shell-hook -e default --shell bash | grep -vie "activate.d" | grep -vie "completion" >> /support/shell-hook.sh \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,12 +7,14 @@ ENV PYTHONWARNINGS=once
 
 # User variables
 ENV USER=uwsgi
+ENV USER_HOME="/home/${USER}"
 ENV USER_UID=988
+ENV PIXI_HOME="${USER_HOME}/.pixi"
 
 # Setup user
 RUN groupadd ${USER} \
     && useradd -rm -d ${USER_HOME} -s /bin/bash -g ${USER} -u ${USER_UID} ${USER}
-RUN mkdir -p /static /media /support
+RUN mkdir -p "${USER_HOME}/app" /static /media /support
 RUN chown -R ${USER}:${USER} ${USER_HOME} /static /media /support
 
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,7 +16,7 @@ ENV PYTHONWARNINGS=once
 ENV USER=uwsgi
 ENV USER_HOME="/home/${USER}"
 ENV APP_DIR="/home/${USER}/app"
-ENV USER_UID=988
+ENV USER_UID=1001
 ENV PIXI_HOME="${USER_HOME}/.pixi"
 
 # Setup user

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,12 @@
 FROM ghcr.io/prefix-dev/pixi:0.66.0 AS base
 
+# Gather required base utils
+RUN apt-get update && apt-get install -y \
+        curl \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 # Output logging faster
 ENV PYTHONUNBUFFERED=1
 # Show deprecation warnings https://docs.djangoproject.com/en/2.2/howto/upgrade-version/#resolving-deprecation-warnings
@@ -33,7 +40,8 @@ ENV IMAGE_TAG=${IMAGE_TAG:-unknown}
 
 ENTRYPOINT ["/bin/bash", "/support/shell-hook.sh"]
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=20s CMD ["curl", "-f", "http://localhost:8000/backend/health/"] || exit 1
+HEALTHCHECK --interval=30s --timeout=10s --start-period=20s \
+    CMD /usr/bin/curl -D- -o /dev/null --silent --fail "http://localhost:8080/backend/health/"
 
 
 FROM base AS develop

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,8 +7,7 @@ ENV PYTHONWARNINGS=once
 
 # User variables
 ENV USER=uwsgi
-ENV USER_HOME="/home/${USER}/"
-ENV USER_UID=1001
+ENV USER_UID=988
 
 # Setup user
 RUN groupadd ${USER} \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,21 +15,22 @@ ENV PYTHONWARNINGS=once
 # User variables
 ENV USER=uwsgi
 ENV USER_HOME="/home/${USER}"
+ENV APP_DIR="/home/${USER}/app"
 ENV USER_UID=988
 ENV PIXI_HOME="${USER_HOME}/.pixi"
 
 # Setup user
 RUN groupadd ${USER} \
     && useradd -rm -d ${USER_HOME} -s /bin/bash -g ${USER} -u ${USER_UID} ${USER}
-RUN mkdir -p /static /media /support /opt/pixi/envs
-RUN chown -R ${USER}:${USER} ${USER_HOME} /static /media /support /opt/pixi/envs
+RUN mkdir -p /static /media /support ${APP_DIR} /opt/pixi/envs
+RUN chown -R ${USER}:${USER} ${USER_HOME} /static /media /support ${APP_DIR} /opt/pixi/envs
 
 USER ${USER}
-WORKDIR ${USER_HOME}
+WORKDIR ${APP_DIR}
 
-COPY --chown=${USER}:${USER} ./pyproject.toml ./pixi.lock ${USER_HOME}
+COPY --chown=${USER}:${USER} ./pyproject.toml ./pixi.lock ${APP_DIR}
 RUN --mount=type=cache,id=br_pixi,target=${USER_HOME}/.cache/rattler/cache,uid=${USER_UID},gid=${USER_UID} \
-    pixi config set detached-environments "/opt/pixi/envs" \
+    pixi config set --global detached-environments "/opt/pixi/envs" \
     && pixi install -e default --frozen --manifest-path ./pyproject.toml
 
 RUN echo '#!/bin/bash' > /support/shell-hook.sh \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/prefix-dev/pixi:0.66.0 AS base
+FROM ghcr.io/prefix-dev/pixi:0.66.0@sha256:e8857b9ba407f92958feb0098c816cae713264251d43bb42217bcedfc8a719fd AS base
 
 # Gather required base utils
 RUN apt-get update && apt-get install -y \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR ${APP_DIR}
 COPY --chown=${USER}:${USER} ./pyproject.toml ./pixi.lock ${APP_DIR}
 RUN --mount=type=cache,id=br_pixi,target=${USER_HOME}/.cache/rattler/cache,uid=${USER_UID},gid=${USER_UID} \
     pixi config set --global detached-environments "/opt/pixi/envs" \
-    && pixi install -e default --frozen --manifest-path ./pyproject.toml
+    && pixi install -e default --frozen
 
 # Copy app source (and only app source)
 COPY --chown=${USER}:${USER} ./manage.py ${APP_DIR}/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,7 +34,6 @@ services:
     command: "python manage.py runserver 0:8080"
     volumes:
       - ./backend:/home/uwsgi/app:cached
-      # - ./docker-data/uwsgi-pixi:/home/uwsgi/.pixi
       - ./docker-data/media:/media:cached
       - ./docker-data/static:/static:cached
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
     image: buoy_retriever_backend
     command: "python manage.py runserver 0:8080"
     volumes:
-      - ./backend:/home/uwsgi:cached
+      - ./backend:/home/uwsgi/app:cached
       - /home/uwsgi/.pixi
       - ./docker-data/media:/media:cached
       - ./docker-data/static:/static:cached

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
     command: "python manage.py runserver 0:8080"
     volumes:
       - ./backend:/home/uwsgi/app:cached
-      - /home/uwsgi/.pixi
+      # - ./docker-data/uwsgi-pixi:/home/uwsgi/.pixi
       - ./docker-data/media:/media:cached
       - ./docker-data/static:/static:cached
     ports:


### PR DESCRIPTION
Addresses the following:

*   Updating the Docker image to honor the `pixi.lock` during build.
*   Updating `pixi` environment within container to be separate from the application directory (using detached environments).
*   Updating Docker image so that it can be build without having a `pixi` environment set up on the host.
*   Avoid creating new home directory binds on host (`/home/uwsgi`).
*   Fixing the `pixi` container entrypoint / shell hook to avoid warnings resulting from looking for shell completions (absent in the container)
*   Fixing up the Dockerfile's built-in healthcheck to use the `CMD <string>` style to avoid always failing healthchecks.