### PR TITLE
Changing app labels and adding buoy_retriever as Django app

### DIFF
--- a/backend/account/apps.py
+++ b/backend/account/apps.py
@@ -4,3 +4,4 @@ from django.apps import AppConfig
 class AccountConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "account"
+    label = "buoy_retriever_account"

--- a/backend/buoy_retriever/apps.py
+++ b/backend/buoy_retriever/apps.py
@@ -1,0 +1,11 @@
+from django.apps import AppConfig
+
+
+class BuoyRetrieverConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "buoy_retriever"
+    label = "buoy_retriever"
+
+    def ready(self):
+        # Initialize signals
+        import buoy_retriever.signals # noqa

--- a/backend/buoy_retriever/settings.py
+++ b/backend/buoy_retriever/settings.py
@@ -144,8 +144,7 @@ DATABASES = {
 }
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-
-AUTH_USER_MODEL = "account.User"
+AUTH_USER_MODEL = "buoy_retriever_account.User"
 
 # Password validation
 # https://docs.djangoproject.com/en/5.2/ref/settings/#auth-password-validators

--- a/backend/buoy_retriever/settings.py
+++ b/backend/buoy_retriever/settings.py
@@ -88,6 +88,7 @@ INSTALLED_APPS = [
     "health_check",
     "health_check.db",
     "corsheaders",
+    "buoy_retriever",
     "guardian",
     "account",
     "datasets",

--- a/backend/buoy_retriever/signals.py
+++ b/backend/buoy_retriever/signals.py
@@ -1,0 +1,13 @@
+import logging
+
+# from django.db.models import Q
+from django.dispatch import receiver
+from django.contrib.auth import get_user_model
+from django.db.models.signals import post_save
+from django.conf import settings
+from django.contrib.auth.models import AbstractUser
+
+
+logger = logging.getLogger(__name__)
+
+# TODO: Placeholder

--- a/backend/pipelines/models.py
+++ b/backend/pipelines/models.py
@@ -27,7 +27,7 @@ class PipelineApiKey(models.Model):
     """API keys for programmatic access to pipelines"""
 
     id = models.AutoField(primary_key=True)
-    user = models.ForeignKey("account.User", on_delete=models.PROTECT)
+    user = models.ForeignKey("buoy_retriever_account.User", on_delete=models.PROTECT)
     name = models.CharField(max_length=255)
     key_value = models.CharField(max_length=255, unique=True, default=_generate_api_key)
 


### PR DESCRIPTION
Addresses the following:

*   Updates the `account` app label to `buoy_retriever_account` in anticipation of conflicts with other third party packages with an `account` app.
*   Provides the app setup for `buoy_retriever` to be an app that is included with the `settings.py` (in anticipation of needing to handle signals between apps in the future).