### PR TITLE
Initialize timescaledb-ha containers as root in docker compose stack

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,10 @@
 services:
   db:
     image: timescale/timescaledb-ha:pg17-ts2.21@sha256:a2f4731fd341e93a96fdc49f21137db0ec27bd3d72a5dab241fec2b344f2f54c
+    # start timescaledb-ha container as root user so it can create host mounted data directories with proper ownership
+    # after init, postgres process will be executed as non-root postgres user using gosu
+    # https://github.com/timescale/timescaledb-docker-ha/blob/v1.16.0/docker-entrypoint.sh#L352-L357
+    user: root
     ports:
       - "${BUOY_RETRIEVER_DB_PORT:-5432}:5432"
     env_file:
@@ -72,6 +76,7 @@ services:
 
   dagster_postgres:
     image: timescale/timescaledb-ha:pg17-ts2.21@sha256:a2f4731fd341e93a96fdc49f21137db0ec27bd3d72a5dab241fec2b344f2f54c
+    user: root
     environment:
       PGDATA: /var/lib/postgresql/data/PGDATA
     env_file:


### PR DESCRIPTION
Update docker-compose.yaml to start timescaledb-ha containers as root user so it can create host mounted data directories with proper ownership. After init, postgres process will be executed as non-root postgres user using gosu.

See https://github.com/timescale/timescaledb-docker-ha/blob/v1.16.0/docker-entrypoint.sh#L352-L357

```
$ docker compose exec db ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
postgres       1  0.3  0.5 25476816 560148 ?     Ss   06:51   0:01 postgres
postgres     124  0.0  0.2 25477072 214260 ?     Ss   06:51   0:00 postgres: checkpointer 
postgres     125  0.0  0.2 25476948 198892 ?     Ss   06:51   0:00 postgres: background writer 
postgres     127  0.0  0.0 25476948 23800 ?      Ss   06:51   0:00 postgres: walwriter 
postgres     128  0.0  0.0 25478412 9188 ?       Ss   06:51   0:00 postgres: autovacuum launcher 
postgres     129  0.0  0.0 25478612 11864 ?      Ss   06:51   0:00 postgres: TimescaleDB Background Worker Launcher 
postgres     130  0.0  0.0 25478428 9572 ?       Ss   06:51   0:00 postgres: logical replication launcher 
postgres     131  0.0  0.0 25481044 30528 ?      Ss   06:51   0:00 postgres: TimescaleDB Background Worker Scheduler for database 16384 
postgres     132  0.0  0.0 25481044 30708 ?      Ss   06:51   0:00 postgres: TimescaleDB Background Worker Scheduler for database 5 
root        1665  0.0  0.0  10464  3288 pts/0    Rs+  06:57   0:00 ps aux
```

Without this, when using rootful Docker on Linux timescaledb-ha is unable to create the `PGDATA` directory within the mounted host directory (e.g. `./docker-data/postgres:/var/lib/postgresql/data`) if the mounted directory is freshly created and/or owned by `root` on the host.

Partially addresses #149 