### PR TITLE
Add docker-data to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 **/.pixi
+docker-data


### PR DESCRIPTION
The `docker-data` directory should not be included in the Docker build context for the various images (including the pipeline images which need their context set to the project root for access to the `./common` directory).

In addition to containing stateful/runtime data that should always be excluded from build contexts, including it will cause builds to fail if any of the files in `./docker-data` are not readable by the build user (e.g. root owned directories).