### PR TITLE
Aveva snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,10 @@ shell:
 test-common:
 	cd common; uv run pytest --cov=.
 
+test-aveva:
+	docker build -f pipeline/aveva/Dockerfile -t buoy_retriever-aveva .
+	docker run  -v ./docker-data/test-data:/mnt/test-data  --env-file ./docker-data/secret.env  buoy_retriever-aveva pixi run pytest --cov=.
+
 test-backend:
 	docker build -t buoy_retriever-backend backend/
 	docker run -v ./docker-data/test-data:/mnt/test-data:ro buoy_retriever-backend pixi run pytest --cov=.

--- a/pipeline/aveva/pixi.lock
+++ b/pipeline/aveva/pixi.lock
@@ -3,6 +3,8 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -627,6 +629,8 @@ environments:
   dev:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -799,8 +803,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-datadir-1.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-env-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-recording-0.13.4-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-regressions-2.11.0-pyhc455866_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.14-h6add32d_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
@@ -1031,8 +1037,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-datadir-1.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-env-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-recording-0.13.4-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-regressions-2.11.0-pyhc455866_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.13.14-h6185564_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
@@ -1257,8 +1265,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-datadir-1.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-env-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-recording-0.13.4-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-regressions-2.11.0-pyhc455866_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.14-h448ec07_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
@@ -6736,6 +6746,16 @@ packages:
   license_family: MIT
   size: 29559
   timestamp: 1774139250481
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-datadir-1.8.0-pyhd8ed1ab_0.conda
+  sha256: 9bb02764223157d4b58f7b193f8cdaf82f36a1ade1cd7df611e09e824ece43d8
+  md5: e46da0323c9a50ef1b53c20d33e243a0
+  depends:
+  - pytest >=7.0
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 12519
+  timestamp: 1753915123443
 - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-env-1.6.0-pyhd8ed1ab_0.conda
   sha256: d288b55b224a1d6a7eca5ca0ac0e026169ffa6458e64dcb990f62f99e37b8010
   md5: 27f9775b96f64454633682cc6a0b0768
@@ -6761,6 +6781,18 @@ packages:
   license_family: MIT
   size: 20398
   timestamp: 1756036224668
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-regressions-2.11.0-pyhc455866_0.conda
+  sha256: ba4413898fc01903ef1291a18842689345364b2d79eaa315851b829754d38818
+  md5: b73569e55629580f6d277fe57cc3c9e3
+  depends:
+  - pytest >=6.2.0
+  - pytest-datadir >=1.7.0
+  - python >=3.10
+  - pyyaml
+  license: MIT
+  license_family: MIT
+  size: 78330
+  timestamp: 1779792061225
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.13-h6add32d_100_cp313.conda
   build_number: 100
   sha256: 7f77eb57648f545c1f58e10035d0d9d66b0a0efb7c4b58d3ed89ec7269afdde1

--- a/pipeline/aveva/pyproject.toml
+++ b/pipeline/aveva/pyproject.toml
@@ -39,6 +39,7 @@ pytest-recording = ">=0.13.4,<0.14"
 pytest-cov = "*"
 moto = ">=5.1.16,<6"
 pytest-env = ">=1.2.0,<2"
+pytest-regressions = ">=2.11.0,<3"
 
 [tool.pixi.feature.dev.tasks]
 pytest = "pytest -vv --ignore=common --record-mode=once"

--- a/pipeline/aveva/tests/conftest.py
+++ b/pipeline/aveva/tests/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytest_plugins = ["common.test_utils.snapshot"]
+
 
 def pytest_addoption(parser):
     parser.addoption(

--- a/pipeline/aveva/tests/test_datasets.py
+++ b/pipeline/aveva/tests/test_datasets.py
@@ -13,6 +13,16 @@ from pipeline import AvevaTimeseriesDataset, defs_for_dataset
 TEST_DATA_DIR = Path("/mnt/test-data/aveva_timeseries/")
 
 
+@pytest.fixture(scope="session")
+def lazy_datadir() -> Path:
+    return TEST_DATA_DIR
+
+
+@pytest.fixture(scope="session")
+def original_datadir() -> Path:
+    return TEST_DATA_DIR
+
+
 @pytest.fixture
 def dataset_config(asset_name, created_dt_str):
     config_path = TEST_DATA_DIR / f"fixtures/{asset_name}.json"
@@ -59,7 +69,7 @@ def test_can_build_defs(defs):
         pytest.param(
             "aveva",
             "2026-05-21T17:08:19.590Z",
-            TEST_DATA_DIR / "test_aveva/test_aveva_20260302.csv",
+            "test_aveva/test_aveva_20260302",
             "2026-03-02",
         ),
     ],
@@ -72,6 +82,7 @@ def test_daily_asset(
     asset_name,
     snapshot_path,
     partition_key,
+    pandas_csv_regression,
 ):
     daily_df = test_utils.get_asset_by_name(defs, "daily_df")
 
@@ -84,15 +95,7 @@ def test_daily_asset(
     assert isinstance(df, pd.DataFrame)
     assert not df.empty
 
-    snapshot = pd.read_csv(
-        snapshot_path,
-    )
-
-    snapshot["time"] = pd.to_datetime(
-        df["time"],
-    )
-
-    pd.testing.assert_frame_equal(df, snapshot)
+    pandas_csv_regression.check(df, basename=snapshot_path)
 
 
 @pytest.mark.parametrize(
@@ -105,7 +108,7 @@ def test_daily_asset(
                 "2026-05-09": TEST_DATA_DIR / "test_aveva/test_aveva_20260509.csv",
                 "2026-05-10": TEST_DATA_DIR / "test_aveva/test_aveva_20260510.csv",
             },
-            TEST_DATA_DIR / "test_aveva/test_aveva_202605.nc",
+            "test_aveva/test_aveva_202605",
             "2026-05-01",
         ),
     ],
@@ -117,6 +120,7 @@ def test_monthly_asset(
     daily_snapshot_dict,
     monthly_snapshot_path,
     monthly_partition_key,
+    nc_io_regression,
 ):
     monthly_ds = test_utils.get_asset_by_name(defs, "monthly_ds")
     spec = monthly_ds.get_asset_spec()
@@ -141,6 +145,4 @@ def test_monthly_asset(
 
     assert isinstance(ds, xr.Dataset)
 
-    snapshot = xr.load_dataset(monthly_snapshot_path, decode_timedelta=False)
-
-    xr.testing.assert_equal(ds, snapshot)
+    nc_io_regression.check(ds, basename=monthly_snapshot_path)


### PR DESCRIPTION
Updates Aveva to use the snapshot fixtures.

I don’t have the API key saved locally to validate the tests that require it. The time formats are likely off (may include a `T` where it isn’t expected, or otherwise).