### PR TITLE
Exploring PostgREST compatible endpoints for Django

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -40,6 +40,7 @@ COPY --chown=${USER}:${USER} ./account ${APP_DIR}/account
 COPY --chown=${USER}:${USER} ./buoy_retriever ${APP_DIR}/buoy_retriever
 COPY --chown=${USER}:${USER} ./datasets ${APP_DIR}/datasets
 COPY --chown=${USER}:${USER} ./pipelines ${APP_DIR}/pipelines
+COPY --chown=${USER}:${USER} ./ninja_postgrest ${APP_DIR}/ninja_postgrest
 
 RUN echo '#!/bin/bash' > /support/shell-hook.sh \
     && pixi shell-hook -e default --shell bash | grep -vie "activate.d" | grep -vie "completion" >> /support/shell-hook.sh \

--- a/backend/buoy_retriever/api.py
+++ b/backend/buoy_retriever/api.py
@@ -1,9 +1,15 @@
 from datasets.api import dataset_router, config_router
-from ninja import NinjaAPI
+from ninja import NinjaAPI, Router
 from pipelines.api import router as pipelines_router
+
+from ninja_postgrest import build_router as build_postgrest_router
 
 api = NinjaAPI(docs_url="/docs/")
 
 api.add_router("/configs/", config_router)
 api.add_router("/datasets/", dataset_router)
 api.add_router("/pipelines/", pipelines_router)
+api.add_router(
+    "/pg/",
+    build_postgrest_router(router=Router(tags=["PostgREST-compatible endpoints"])),
+)

--- a/backend/buoy_retriever/settings.py
+++ b/backend/buoy_retriever/settings.py
@@ -88,10 +88,32 @@ INSTALLED_APPS = [
     "health_check",
     "corsheaders",
     "guardian",
+    "ninja_postgrest",
     "account",
     "datasets",
     "pipelines",
 ]
+
+# PostgREST-compatible endpoints (see the ninja_postgrest app).
+NINJA_POSTGREST = {
+    "DEFAULT_AUTH": ["ninja.security.django_auth", "pipelines.api.PipelineApiKeyAuth"],
+    "DEFAULT_PERMISSIONS": "guardian",
+    "MAX_LIMIT": 1000,
+    "TABLES": {
+        "datasets": {
+            "model": "datasets.Dataset",
+            "embeddable": ["configs", "pipeline"],
+        },
+        "dataset_configs": {
+            "model": "datasets.DatasetConfig",
+            "embeddable": ["dataset"],
+        },
+        "pipelines": {
+            "model": "pipelines.Pipeline",
+            "embeddable": ["datasets"],
+        },
+    },
+}
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",

--- a/backend/buoy_retriever/settings.py
+++ b/backend/buoy_retriever/settings.py
@@ -96,7 +96,10 @@ INSTALLED_APPS = [
 
 # PostgREST-compatible endpoints (see the ninja_postgrest app).
 NINJA_POSTGREST = {
-    "DEFAULT_AUTH": ["ninja.security.django_auth", "pipelines.api.PipelineApiKeyAuth"],
+    "DEFAULT_AUTH": [
+        "ninja.security.django_auth",
+        "pipelines.api.pipeline_api_key_auth",
+    ],
     "DEFAULT_PERMISSIONS": "guardian",
     "MAX_LIMIT": 1000,
     "TABLES": {

--- a/backend/ninja_postgrest/Conformance.md
+++ b/backend/ninja_postgrest/Conformance.md
@@ -21,7 +21,8 @@ for the open work behind the deviations below.
 
 ### Selection & embedding
 - `select` projection: bare columns, `alias:col`, `col::cast` (cast is
-  informational), JSON paths `col->a->>b`.
+  informational), JSON paths `col->a->>b`. `->>` extracts as text (matching
+  PostgREST); `->` extracts the raw JSON value.
 - Resource embedding `relation(col,...)` with aliases and arbitrary nesting.
 - Forward FK/O2O embeds resolve to a single object (or `null`); reverse-FK/M2M
   embeds resolve to an array.
@@ -75,7 +76,6 @@ for the open work behind the deviations below.
 |------|-----------|----------|----------|
 | Error `code` values | Real codes (`PGRST116`, `PGRST100`, ...) and pass-through Postgres `SQLSTATE`s | `PGRST116` (singular no/multiple rows) and `PGRST100` (query-parse) now match PostgREST exactly. Remaining hyphenated `PGRST-4xx` codes are app-specific markers with no exact PostgREST equivalent (PostgREST would surface a Postgres `SQLSTATE` or a `PGRST2xx` there): `PGRST-400` (not-filterable/not-writable column, bad embed, invalid body, unknown `on_conflict`/`columns`), `PGRST-403` (permission denied), `PGRST-404` (unknown table) | [F-7](./Findings.md) |
 | JSON-path filtering | `config->>x=eq.y` filters on JSON paths | Rejected with 400; JSON paths work in `select` only | README v1 limitation |
-| `->>` text cast in `select` | `->>` returns the value as *text* (`"2"`) | The parsed `->`/`->>` distinction is not applied during serialization: both return the raw JSON value (`2`, `true`, objects) | [F-10](./Findings.md) |
 | Forward-embed permissions | — | Forward (FK/O2O) embeds of registered models are **not** permission-filtered; only reverse-FK/M2M embeds are (the parent row is already authorized) | README v1 limitation |
 | FK disambiguation | `relation!fk(...)` picks a specific FK | Not supported | README v1 limitation |
 | RPC | `POST /rpc/{fn}` | Not implemented | README v1 limitation |

--- a/backend/ninja_postgrest/Conformance.md
+++ b/backend/ninja_postgrest/Conformance.md
@@ -52,6 +52,9 @@ for the open work behind the deviations below.
 - Upsert via `Prefer: resolution=merge-duplicates` / `ignore-duplicates` plus
   `?on_conflict=col[,col2]`; without an `on_conflict` target the request
   degrades to a plain insert.
+- `?columns=col[,col2]` restricts the insert column set (`POST` only): body
+  keys not listed are ignored (dropped/defaulted) rather than rejected, for
+  both plain inserts and upserts.
 
 ### Errors
 - JSON error body shape `{message, details, hint, code}`.
@@ -63,7 +66,6 @@ for the open work behind the deviations below.
 | Error `code` values | Codes like `PGRST116` (no/multiple rows), and pass-through Postgres `SQLSTATE`s | Custom codes (`PGRST-400`, `PGRST-406`, ...). A client keying on `err.code` will not see real PostgREST codes | [F-7](./Findings.md) |
 | Insert `Location` header | Returns a `Location` header for created rows | Not set | [F-8](./Findings.md) |
 | Singular `Accept` on writes | `PATCH`/`DELETE` honour the singular media type | `PATCH`/`DELETE` always return an array | [F-8](./Findings.md) |
-| `columns` param | Restricts the columns considered on insert | Reserved but unimplemented — `?columns=` is silently ignored | [F-4](./Findings.md) |
 | JSON-path filtering | `config->>x=eq.y` filters on JSON paths | Rejected with 400; JSON paths work in `select` only | README v1 limitation |
 | Forward-embed permissions | — | Forward (FK/O2O) embeds of registered models are **not** permission-filtered; only reverse-FK/M2M embeds are (the parent row is already authorized) | README v1 limitation |
 | FK disambiguation | `relation!fk(...)` picks a specific FK | Not supported | README v1 limitation |

--- a/backend/ninja_postgrest/Conformance.md
+++ b/backend/ninja_postgrest/Conformance.md
@@ -58,12 +58,16 @@ for the open work behind the deviations below.
 
 ### Errors
 - JSON error body shape `{message, details, hint, code}`.
+- Singular response with 0 or >1 rows returns `code: "PGRST116"` (status 406),
+  matching real PostgREST.
+- Query-string / operator parse errors return `code: "PGRST100"` (status 400),
+  matching real PostgREST.
 
 ## Deviates
 
 | Area | PostgREST | This app | Tracking |
 |------|-----------|----------|----------|
-| Error `code` values | Codes like `PGRST116` (no/multiple rows), and pass-through Postgres `SQLSTATE`s | Custom codes (`PGRST-400`, `PGRST-406`, ...). A client keying on `err.code` will not see real PostgREST codes | [F-7](./Findings.md) |
+| Error `code` values | Real codes (`PGRST116`, `PGRST100`, ...) and pass-through Postgres `SQLSTATE`s | `PGRST116` (singular no/multiple rows) and `PGRST100` (query-parse) now match PostgREST exactly. Remaining hyphenated `PGRST-4xx` codes are app-specific markers with no exact PostgREST equivalent (PostgREST would surface a Postgres `SQLSTATE` or a `PGRST2xx` there): `PGRST-400` (not-filterable/not-writable column, bad embed, invalid body, unknown `on_conflict`/`columns`), `PGRST-403` (permission denied), `PGRST-404` (unknown table) | [F-7](./Findings.md) |
 | Insert `Location` header | Returns a `Location` header for created rows | Not set | [F-8](./Findings.md) |
 | Singular `Accept` on writes | `PATCH`/`DELETE` honour the singular media type | `PATCH`/`DELETE` always return an array | [F-8](./Findings.md) |
 | JSON-path filtering | `config->>x=eq.y` filters on JSON paths | Rejected with 400; JSON paths work in `select` only | README v1 limitation |

--- a/backend/ninja_postgrest/Conformance.md
+++ b/backend/ninja_postgrest/Conformance.md
@@ -34,6 +34,8 @@ for the open work behind the deviations below.
 - `Range: 0-9` request header (query params take precedence).
 - `MAX_LIMIT` hard cap on rows returned per request (analogous to PostgREST's
   `db-max-rows`).
+- `DEFAULT_LIMIT` is the default page size applied when a request gives no
+  `limit`/`Range`, still bounded by `MAX_LIMIT`.
 
 ### Responses
 - `Content-Range` response header, including the empty-page `*/<total>` form.
@@ -58,7 +60,6 @@ for the open work behind the deviations below.
 
 | Area | PostgREST | This app | Tracking |
 |------|-----------|----------|----------|
-| Default page size | `db-max-rows` caps; a server may set a default limit | Only `MAX_LIMIT` (the cap) is honoured. `DEFAULT_LIMIT` is read from settings and documented but never applied, so there is no default page size below the cap | [F-2](./Findings.md) |
 | Error `code` values | Codes like `PGRST116` (no/multiple rows), and pass-through Postgres `SQLSTATE`s | Custom codes (`PGRST-400`, `PGRST-406`, ...). A client keying on `err.code` will not see real PostgREST codes | [F-7](./Findings.md) |
 | Insert `Location` header | Returns a `Location` header for created rows | Not set | [F-8](./Findings.md) |
 | Singular `Accept` on writes | `PATCH`/`DELETE` honour the singular media type | `PATCH`/`DELETE` always return an array | [F-8](./Findings.md) |

--- a/backend/ninja_postgrest/Conformance.md
+++ b/backend/ninja_postgrest/Conformance.md
@@ -74,6 +74,7 @@ for the open work behind the deviations below.
 |------|-----------|----------|----------|
 | Error `code` values | Real codes (`PGRST116`, `PGRST100`, ...) and pass-through Postgres `SQLSTATE`s | `PGRST116` (singular no/multiple rows) and `PGRST100` (query-parse) now match PostgREST exactly. Remaining hyphenated `PGRST-4xx` codes are app-specific markers with no exact PostgREST equivalent (PostgREST would surface a Postgres `SQLSTATE` or a `PGRST2xx` there): `PGRST-400` (not-filterable/not-writable column, bad embed, invalid body, unknown `on_conflict`/`columns`), `PGRST-403` (permission denied), `PGRST-404` (unknown table) | [F-7](./Findings.md) |
 | JSON-path filtering | `config->>x=eq.y` filters on JSON paths | Rejected with 400; JSON paths work in `select` only | README v1 limitation |
+| `->>` text cast in `select` | `->>` returns the value as *text* (`"2"`) | The parsed `->`/`->>` distinction is not applied during serialization: both return the raw JSON value (`2`, `true`, objects) | [F-10](./Findings.md) |
 | Forward-embed permissions | — | Forward (FK/O2O) embeds of registered models are **not** permission-filtered; only reverse-FK/M2M embeds are (the parent row is already authorized) | README v1 limitation |
 | FK disambiguation | `relation!fk(...)` picks a specific FK | Not supported | README v1 limitation |
 | RPC | `POST /rpc/{fn}` | Not implemented | README v1 limitation |

--- a/backend/ninja_postgrest/Conformance.md
+++ b/backend/ninja_postgrest/Conformance.md
@@ -45,6 +45,11 @@ for the open work behind the deviations below.
 - Single-object insert returns an array (collapsed to one object only under the
   singular media type).
 - `Prefer: return=representation` returns affected rows on write.
+- Insert (`POST`) sets a `Location` header pointing at the created row(s) (a PK
+  filter: `?id=eq.5`, or `?id=in.(1,2)` for a bulk insert).
+- `PATCH` / `DELETE` honour the singular media type when returning a
+  representation: 406 (`PGRST116`) unless exactly one row is affected, and the
+  write does not take effect (rolled back / not deleted) on that 406.
 
 ### Writes
 - `POST` insert of one object or an array.
@@ -68,8 +73,6 @@ for the open work behind the deviations below.
 | Area | PostgREST | This app | Tracking |
 |------|-----------|----------|----------|
 | Error `code` values | Real codes (`PGRST116`, `PGRST100`, ...) and pass-through Postgres `SQLSTATE`s | `PGRST116` (singular no/multiple rows) and `PGRST100` (query-parse) now match PostgREST exactly. Remaining hyphenated `PGRST-4xx` codes are app-specific markers with no exact PostgREST equivalent (PostgREST would surface a Postgres `SQLSTATE` or a `PGRST2xx` there): `PGRST-400` (not-filterable/not-writable column, bad embed, invalid body, unknown `on_conflict`/`columns`), `PGRST-403` (permission denied), `PGRST-404` (unknown table) | [F-7](./Findings.md) |
-| Insert `Location` header | Returns a `Location` header for created rows | Not set | [F-8](./Findings.md) |
-| Singular `Accept` on writes | `PATCH`/`DELETE` honour the singular media type | `PATCH`/`DELETE` always return an array | [F-8](./Findings.md) |
 | JSON-path filtering | `config->>x=eq.y` filters on JSON paths | Rejected with 400; JSON paths work in `select` only | README v1 limitation |
 | Forward-embed permissions | — | Forward (FK/O2O) embeds of registered models are **not** permission-filtered; only reverse-FK/M2M embeds are (the parent row is already authorized) | README v1 limitation |
 | FK disambiguation | `relation!fk(...)` picks a specific FK | Not supported | README v1 limitation |

--- a/backend/ninja_postgrest/Conformance.md
+++ b/backend/ninja_postgrest/Conformance.md
@@ -47,9 +47,10 @@ for the open work behind the deviations below.
 - `Prefer: return=representation` returns affected rows on write.
 - Insert (`POST`) sets a `Location` header pointing at the created row(s) (a PK
   filter: `?id=eq.5`, or `?id=in.(1,2)` for a bulk insert).
-- `PATCH` / `DELETE` honour the singular media type when returning a
+- `POST` / `PATCH` / `DELETE` honour the singular media type when returning a
   representation: 406 (`PGRST116`) unless exactly one row is affected, and the
-  write does not take effect (rolled back / not deleted) on that 406.
+  write does not take effect (insert / update rolled back, or nothing deleted)
+  on that 406 — a bulk `POST` under the singular media type inserts nothing.
 
 ### Writes
 - `POST` insert of one object or an array.

--- a/backend/ninja_postgrest/Conformance.md
+++ b/backend/ninja_postgrest/Conformance.md
@@ -1,0 +1,72 @@
+# PostgREST conformance
+
+How `ninja_postgrest` maps onto the [PostgREST](https://postgrest.org) API, and
+where it currently deviates. This is a v1 implementation targeting the common
+read/write surface used by the standard
+[`postgrest`](https://pypi.org/project/postgrest/) client, not full parity.
+
+See [README.md](./README.md) for configuration and [Findings.md](./Findings.md)
+for the open work behind the deviations below.
+
+## Conforms
+
+### Filtering
+- Horizontal filters `?col=op.value`, repeatable (`&`-combined as AND).
+- `not.` negation prefix on any operator.
+- Logical groups `or=(...)` / `and=(...)`, including nesting and `not.and(...)` /
+  `not.or(...)`. Columns inside a group honour the same `filterable` allowlist as
+  plain filters.
+- Operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `like`, `ilike`, `match`,
+  `imatch`, `in`, `is`, `cs`, `cd`, `ov`, `fts`/`plfts`/`phfts`/`wfts`.
+  (`isdistinct` is implemented but has a NULL bug — see Deviates.)
+
+### Selection & embedding
+- `select` projection: bare columns, `alias:col`, `col::cast` (cast is
+  informational), JSON paths `col->a->>b`.
+- Resource embedding `relation(col,...)` with aliases and arbitrary nesting.
+- Forward FK/O2O embeds resolve to a single object (or `null`); reverse-FK/M2M
+  embeds resolve to an array.
+- Foreign keys surface as their scalar `*_id` column; the relation name is used
+  only for embeds.
+
+### Ordering & pagination
+- `order` with `asc`/`desc` and `nullsfirst`/`nullslast`, multiple terms.
+- `limit` / `offset` query params.
+- `Range: 0-9` request header (query params take precedence).
+- `MAX_LIMIT` hard cap on rows returned per request (analogous to PostgREST's
+  `db-max-rows`).
+
+### Responses
+- `Content-Range` response header, including the empty-page `*/<total>` form.
+- `Prefer: count=exact` adds the exact total to `Content-Range`.
+- Singular responses via `Accept: application/vnd.pgrst.object+json`, returning
+  406 unless exactly one row matches (on `GET`).
+- Single-object insert returns an array (collapsed to one object only under the
+  singular media type).
+- `Prefer: return=representation` returns affected rows on write.
+
+### Writes
+- `POST` insert of one object or an array.
+- `PATCH` / `DELETE` of rows matching the request filters.
+- Upsert via `Prefer: resolution=merge-duplicates` / `ignore-duplicates` plus
+  `?on_conflict=col[,col2]`; without an `on_conflict` target the request
+  degrades to a plain insert.
+
+### Errors
+- JSON error body shape `{message, details, hint, code}`.
+
+## Deviates
+
+| Area | PostgREST | This app | Tracking |
+|------|-----------|----------|----------|
+| `isdistinct` | `IS DISTINCT FROM` is NULL-safe (`NULL isdistinct 5` → true) | Compiled as `~Q(col__exact=v)`, which excludes `NULL` rows — a matching NULL row is dropped | [F-1](./Findings.md) |
+| Default page size | `db-max-rows` caps; a server may set a default limit | Only `MAX_LIMIT` (the cap) is honoured. `DEFAULT_LIMIT` is read from settings and documented but never applied, so there is no default page size below the cap | [F-2](./Findings.md) |
+| Error `code` values | Codes like `PGRST116` (no/multiple rows), and pass-through Postgres `SQLSTATE`s | Custom codes (`PGRST-400`, `PGRST-406`, ...). A client keying on `err.code` will not see real PostgREST codes | [F-7](./Findings.md) |
+| Insert `Location` header | Returns a `Location` header for created rows | Not set | [F-8](./Findings.md) |
+| Singular `Accept` on writes | `PATCH`/`DELETE` honour the singular media type | `PATCH`/`DELETE` always return an array | [F-8](./Findings.md) |
+| `columns` param | Restricts the columns considered on insert | Reserved but unimplemented — `?columns=` is silently ignored | [F-4](./Findings.md) |
+| JSON-path filtering | `config->>x=eq.y` filters on JSON paths | Rejected with 400; JSON paths work in `select` only | README v1 limitation |
+| Forward-embed permissions | — | Forward (FK/O2O) embeds of registered models are **not** permission-filtered; only reverse-FK/M2M embeds are (the parent row is already authorized) | README v1 limitation |
+| FK disambiguation | `relation!fk(...)` picks a specific FK | Not supported | README v1 limitation |
+| RPC | `POST /rpc/{fn}` | Not implemented | README v1 limitation |
+| PG-only operators | Work on PostgreSQL | `cs`/`cd`/`ov` and the FTS family require a PostgreSQL backend (no-op/raise on SQLite) | README v1 limitation |

--- a/backend/ninja_postgrest/Conformance.md
+++ b/backend/ninja_postgrest/Conformance.md
@@ -17,8 +17,7 @@ for the open work behind the deviations below.
   `not.or(...)`. Columns inside a group honour the same `filterable` allowlist as
   plain filters.
 - Operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `like`, `ilike`, `match`,
-  `imatch`, `in`, `is`, `cs`, `cd`, `ov`, `fts`/`plfts`/`phfts`/`wfts`.
-  (`isdistinct` is implemented but has a NULL bug — see Deviates.)
+  `imatch`, `in`, `is`, `isdistinct`, `cs`, `cd`, `ov`, `fts`/`plfts`/`phfts`/`wfts`.
 
 ### Selection & embedding
 - `select` projection: bare columns, `alias:col`, `col::cast` (cast is
@@ -59,7 +58,6 @@ for the open work behind the deviations below.
 
 | Area | PostgREST | This app | Tracking |
 |------|-----------|----------|----------|
-| `isdistinct` | `IS DISTINCT FROM` is NULL-safe (`NULL isdistinct 5` → true) | Compiled as `~Q(col__exact=v)`, which excludes `NULL` rows — a matching NULL row is dropped | [F-1](./Findings.md) |
 | Default page size | `db-max-rows` caps; a server may set a default limit | Only `MAX_LIMIT` (the cap) is honoured. `DEFAULT_LIMIT` is read from settings and documented but never applied, so there is no default page size below the cap | [F-2](./Findings.md) |
 | Error `code` values | Codes like `PGRST116` (no/multiple rows), and pass-through Postgres `SQLSTATE`s | Custom codes (`PGRST-400`, `PGRST-406`, ...). A client keying on `err.code` will not see real PostgREST codes | [F-7](./Findings.md) |
 | Insert `Location` header | Returns a `Location` header for created rows | Not set | [F-8](./Findings.md) |

--- a/backend/ninja_postgrest/Findings.md
+++ b/backend/ninja_postgrest/Findings.md
@@ -1,0 +1,71 @@
+# Findings & open work
+
+Tracked follow-ups for `ninja_postgrest`, so they survive across sessions.
+Grouped by kind and roughly in priority order. IDs (F-N) are referenced from
+[Conformance.md](./Conformance.md).
+
+Status legend: `[ ]` open · `[~]` in progress · `[x]` done.
+
+## Correctness
+
+- [ ] **F-1 — `isdistinct` drops NULL rows.** `operators.py` compiles
+  `isdistinct` as `~Q(col__exact=value)`, which (like Django's `.exclude()`)
+  excludes rows where the column `IS NULL`. PostgREST's `IS DISTINCT FROM` is
+  NULL-safe, so a NULL row is *distinct* from any non-null value and should be
+  returned. Fix: `~Q(col__exact=value) | Q(col__isnull=True)`. Add a test with a
+  NULL-valued column. (`neq` is fine as-is — `<>` also excludes NULLs.)
+
+- [ ] **F-2 — `DEFAULT_LIMIT` is loaded but never applied.**
+  `conf.py` reads `default_limit` and it appears in the README config example,
+  but `query.slice_queryset` only consults `max_limit`. Either wire
+  `default_limit` in as the effective page size when the request specifies no
+  `limit`/`Range`, or remove the setting and its README mention.
+
+## Dead code / cleanup
+
+- [ ] **F-3 — `schemas.py` is unused.** `get_full_schema`,
+  `reset_schema_cache`, and `JsonBody` have no call sites, so the intended
+  OpenAPI full-row response schema is never generated (routes register raw view
+  callables with no `response=`). Either wire `get_full_schema` into
+  `router.add_api_operation(..., response=...)`, or delete the module.
+
+- [ ] **F-4 — `columns` reserved param is a no-op.** `parsing.RESERVED_PARAMS`
+  reserves `columns` but nothing implements PostgREST's insert column
+  restriction, so `?columns=` is silently ignored. Implement it or drop it from
+  the reserved set and note the gap.
+
+## Tests
+
+- [ ] **F-5 — Reduce duplication between `test_endpoints.py` and
+  `test_postgrest_client.py`.** The client suite re-covers plain CRUD/filter
+  cases the raw-URL suite already asserts identically (`select`+`order`,
+  `filter_eq`, `filter_in`, `limit`, `count_exact`, forward/reverse embed,
+  single-object, basic insert/bulk/update/delete). Keep the client suite focused
+  on what only it can exercise — the wire grammar the `postgrest` library emits,
+  session-cookie auth, `APIError` JSON-shape assertions, and guardian-filtered
+  writes — and let `test_endpoints.py` own the plain CRUD/filter matrix.
+
+- [ ] **F-6 — Fill operator/feature coverage holes.** No tests currently cover:
+  `match`/`imatch`, `isdistinct` (hides F-1), array/range ops `cs`/`cd`/`ov`,
+  the FTS family `fts`/`plfts`/`phfts`/`wfts`; nor `Range`-header pagination,
+  `offset`, `nullsfirst`/`nullslast` ordering, JSON-path *serialization*
+  (`_dig_json` is parsed but never rendered end-to-end), or `select`
+  alias/`::cast` output keys. Prefer adding the grammar-level ones through the
+  `postgrest` client (`.match`, `.contains`, `.text_search`, `.range`) so they
+  are verified against real client output. PG-only operators need a PostgreSQL
+  backend or a documented skip.
+
+## Standard parity (larger scope)
+
+- [ ] **F-7 — Error codes.** Emit PostgREST-compatible `code` values (e.g.
+  `PGRST116` for no/multiple rows on singular) instead of the custom `PGRST-4xx`
+  strings, so clients keying on `err.code` behave as they would against
+  PostgREST.
+
+- [ ] **F-8 — Write-response parity.** Set a `Location` header on insert, and
+  honour the singular `application/vnd.pgrst.object+json` media type on
+  `PATCH`/`DELETE` (currently they always return an array).
+
+- [ ] **F-9 — Documented v1 gaps** (from README "Known limitations"): RPC
+  (`POST /rpc/{fn}`), FK disambiguation (`relation!fk(...)`), JSON-path
+  *filtering*, and forward-embed permission filtering.

--- a/backend/ninja_postgrest/Findings.md
+++ b/backend/ninja_postgrest/Findings.md
@@ -15,7 +15,7 @@ Status legend: `[ ]` open · `[~]` in progress · `[x]` done.
   returned. Fix: `~Q(col__exact=value) | Q(col__isnull=True)`. Add a test with a
   NULL-valued column. (`neq` is fine as-is — `<>` also excludes NULLs.)
 
-- [ ] **F-2 — `DEFAULT_LIMIT` is loaded but never applied.**
+- [x] **F-2 — `DEFAULT_LIMIT` is loaded but never applied.**
   `conf.py` reads `default_limit` and it appears in the README config example,
   but `query.slice_queryset` only consults `max_limit`. Either wire
   `default_limit` in as the effective page size when the request specifies no

--- a/backend/ninja_postgrest/Findings.md
+++ b/backend/ninja_postgrest/Findings.md
@@ -33,10 +33,14 @@ Status legend: `[ ]` open · `[~]` in progress · `[x]` done.
   since generated views return `HttpResponse` directly). `reset_schema_cache`
   is called from `reset_registry()`. `JsonBody` (no call sites) was removed.
 
-- [ ] **F-4 — `columns` reserved param is a no-op.** `parsing.RESERVED_PARAMS`
+- [x] **F-4 — `columns` reserved param is a no-op.** `parsing.RESERVED_PARAMS`
   reserves `columns` but nothing implements PostgREST's insert column
   restriction, so `?columns=` is silently ignored. Implement it or drop it from
   the reserved set and note the gap.
+  Resolved: `views.py` filters `items` to the `?columns=` set (a listed column
+  must be writable, else 400) right after the body is parsed, before the
+  upsert/plain-insert branch, so both paths honour it. `POST` only, per
+  PostgREST semantics.
 
 ## Tests
 

--- a/backend/ninja_postgrest/Findings.md
+++ b/backend/ninja_postgrest/Findings.md
@@ -44,7 +44,7 @@ Status legend: `[ ]` open · `[~]` in progress · `[x]` done.
 
 ## Tests
 
-- [ ] **F-5 — Reduce duplication between `test_endpoints.py` and
+- [x] **F-5 — Reduce duplication between `test_endpoints.py` and
   `test_postgrest_client.py`.** The client suite re-covers plain CRUD/filter
   cases the raw-URL suite already asserts identically (`select`+`order`,
   `filter_eq`, `filter_in`, `limit`, `count_exact`, forward/reverse embed,
@@ -52,6 +52,14 @@ Status legend: `[ ]` open · `[~]` in progress · `[x]` done.
   on what only it can exercise — the wire grammar the `postgrest` library emits,
   session-cookie auth, `APIError` JSON-shape assertions, and guardian-filtered
   writes — and let `test_endpoints.py` own the plain CRUD/filter matrix.
+  Resolved: the resolution direction was inverted by decision — the client
+  suite (`test_postgrest_client.py`) owns the duplicated CRUD/filter cases
+  since it exercises the real wire grammar the `postgrest` library emits;
+  `test_endpoints.py` keeps only raw-only concerns (auth/status codes,
+  headers, settings overrides, and behaviors the client can't express). The
+  11 raw-URL duplicates were removed from `test_endpoints.py` in favor of
+  their existing `test_postgrest_client.py` counterparts, and
+  `test_client_select_and_order` was extended to cover `desc` ordering.
 
 - [ ] **F-6 — Fill operator/feature coverage holes.** No tests currently cover:
   `match`/`imatch`, `isdistinct` (hides F-1), array/range ops `cs`/`cd`/`ov`,

--- a/backend/ninja_postgrest/Findings.md
+++ b/backend/ninja_postgrest/Findings.md
@@ -61,7 +61,7 @@ Status legend: `[ ]` open · `[~]` in progress · `[x]` done.
   their existing `test_postgrest_client.py` counterparts, and
   `test_client_select_and_order` was extended to cover `desc` ordering.
 
-- [ ] **F-6 — Fill operator/feature coverage holes.** No tests currently cover:
+- [x] **F-6 — Fill operator/feature coverage holes.** No tests currently cover:
   `match`/`imatch`, `isdistinct` (hides F-1), array/range ops `cs`/`cd`/`ov`,
   the FTS family `fts`/`plfts`/`phfts`/`wfts`; nor `Range`-header pagination,
   `offset`, `nullsfirst`/`nullslast` ordering, JSON-path *serialization*
@@ -70,6 +70,22 @@ Status legend: `[ ]` open · `[~]` in progress · `[x]` done.
   `postgrest` client (`.match`, `.contains`, `.text_search`, `.range`) so they
   are verified against real client output. PG-only operators need a PostgreSQL
   backend or a documented skip.
+  Resolved: split by what SQLite can execute. `match`/`imatch`,
+  `isdistinct` (non-NULL path), `offset`, `Range`-header pagination (via
+  `.range`/`.offset`, which emit `limit`/`offset` query params on this
+  `postgrest` client version rather than a `Range` header), `nullsfirst`/
+  `nullslast` ordering grammar, `select` alias and `::cast` output keys, and
+  JSON-path serialization (`config->>units`, aliased nested digs) are all
+  covered end-to-end through the real client (`test_postgrest_client.py`) and
+  raw URLs (`test_endpoints.py`). `cs`/`cd`/`ov` and the FTS family
+  (`fts`/`plfts`/`phfts`/`wfts`, incl. the `fts(config)` modifier) get
+  grammar-level `Q`-shape unit tests in `test_operators.py` only, since no
+  registered model has an ArrayField (cs/cd/ov) and SQLite has no
+  `to_tsvector`/`@@` support (FTS). FTS additionally gets one documented
+  `skipif(connection.vendor != "postgresql")` endpoint test in
+  `test_endpoints.py` that will run if the suite is ever pointed at
+  PostgreSQL; `cs`/`cd`/`ov` get no endpoint test even under skipif, since a
+  PG run would still fail with no ArrayField model to exercise.
 
 ## Standard parity (larger scope)
 
@@ -96,3 +112,14 @@ Status legend: `[ ]` open · `[~]` in progress · `[x]` done.
 - [ ] **F-9 — Documented v1 gaps** (from README "Known limitations"): RPC
   (`POST /rpc/{fn}`), FK disambiguation (`relation!fk(...)`), JSON-path
   *filtering*, and forward-embed permission filtering.
+
+- [ ] **F-10 — `->>` does not cast to text in `select`.** Surfaced while
+  writing F-6's JSON-path serialization tests: parsing records the `->` vs
+  `->>` distinction (`SelectField.json_text`), but serialization never
+  consults it — `_dig_json` returns the raw JSON value either way, so
+  `select=depth:config->nested->>depth` yields `2` (int) where PostgREST
+  returns `"2"` (text). Fix would be to coerce in `_serialize_field` when
+  `json_text` is set (PostgREST semantics: strings unquoted, other values as
+  JSON text, `null` stays `NULL`), then update
+  `test_client_json_path_serialization` to pin the text form. Documented in
+  the Conformance Deviates table until then.

--- a/backend/ninja_postgrest/Findings.md
+++ b/backend/ninja_postgrest/Findings.md
@@ -8,7 +8,7 @@ Status legend: `[ ]` open · `[~]` in progress · `[x]` done.
 
 ## Correctness
 
-- [ ] **F-1 — `isdistinct` drops NULL rows.** `operators.py` compiles
+- [x] **F-1 — `isdistinct` drops NULL rows.** `operators.py` compiles
   `isdistinct` as `~Q(col__exact=value)`, which (like Django's `.exclude()`)
   excludes rows where the column `IS NULL`. PostgREST's `IS DISTINCT FROM` is
   NULL-safe, so a NULL row is *distinct* from any non-null value and should be

--- a/backend/ninja_postgrest/Findings.md
+++ b/backend/ninja_postgrest/Findings.md
@@ -65,10 +65,15 @@ Status legend: `[ ]` open · `[~]` in progress · `[x]` done.
 
 ## Standard parity (larger scope)
 
-- [ ] **F-7 — Error codes.** Emit PostgREST-compatible `code` values (e.g.
+- [x] **F-7 — Error codes.** Emit PostgREST-compatible `code` values (e.g.
   `PGRST116` for no/multiple rows on singular) instead of the custom `PGRST-4xx`
   strings, so clients keying on `err.code` behave as they would against
   PostgREST.
+  Resolved: targeted subset applied — `PGRST-406`→`PGRST116` (singular
+  no/multiple-rows) and `PGRST-100`→`PGRST100` (query-parse), both with HTTP
+  statuses unchanged. The remaining `PGRST-400`/`PGRST-403`/`PGRST-404` codes
+  are kept as-is and documented in `Conformance.md` as app-specific markers
+  with no exact PostgREST equivalent.
 
 - [ ] **F-8 — Write-response parity.** Set a `Location` header on insert, and
   honour the singular `application/vnd.pgrst.object+json` media type on

--- a/backend/ninja_postgrest/Findings.md
+++ b/backend/ninja_postgrest/Findings.md
@@ -75,9 +75,15 @@ Status legend: `[ ]` open · `[~]` in progress · `[x]` done.
   are kept as-is and documented in `Conformance.md` as app-specific markers
   with no exact PostgREST equivalent.
 
-- [ ] **F-8 — Write-response parity.** Set a `Location` header on insert, and
+- [x] **F-8 — Write-response parity.** Set a `Location` header on insert, and
   honour the singular `application/vnd.pgrst.object+json` media type on
   `PATCH`/`DELETE` (currently they always return an array).
+  Resolved: `POST` sets `Location` to the request path plus a PK filter
+  (`?id=eq.5`, or `?id=in.(1,2)` for a bulk insert) on every 201. `PATCH`/
+  `DELETE` honour the singular media type when returning a representation:
+  406 (`PGRST116`) unless exactly one row is affected, validated before the
+  write takes effect (inside the update transaction so it rolls back; before
+  `qs.delete()` for delete) so the mutation does not happen on a 406.
 
 - [ ] **F-9 — Documented v1 gaps** (from README "Known limitations"): RPC
   (`POST /rpc/{fn}`), FK disambiguation (`relation!fk(...)`), JSON-path

--- a/backend/ninja_postgrest/Findings.md
+++ b/backend/ninja_postgrest/Findings.md
@@ -113,7 +113,7 @@ Status legend: `[ ]` open · `[~]` in progress · `[x]` done.
   (`POST /rpc/{fn}`), FK disambiguation (`relation!fk(...)`), JSON-path
   *filtering*, and forward-embed permission filtering.
 
-- [ ] **F-10 — `->>` does not cast to text in `select`.** Surfaced while
+- [x] **F-10 — `->>` does not cast to text in `select`.** Surfaced while
   writing F-6's JSON-path serialization tests: parsing records the `->` vs
   `->>` distinction (`SelectField.json_text`), but serialization never
   consults it — `_dig_json` returns the raw JSON value either way, so
@@ -123,3 +123,7 @@ Status legend: `[ ]` open · `[~]` in progress · `[x]` done.
   JSON text, `null` stays `NULL`), then update
   `test_client_json_path_serialization` to pin the text form. Documented in
   the Conformance Deviates table until then.
+  Resolved: added `_json_text` in `serialization.py`, applied in
+  `_serialize_field` when `node.json_text` is set — strings pass through
+  unchanged, `None` stays `None`, everything else (numbers, booleans,
+  objects, arrays) goes through `json.dumps`.

--- a/backend/ninja_postgrest/Findings.md
+++ b/backend/ninja_postgrest/Findings.md
@@ -23,11 +23,15 @@ Status legend: `[ ]` open · `[~]` in progress · `[x]` done.
 
 ## Dead code / cleanup
 
-- [ ] **F-3 — `schemas.py` is unused.** `get_full_schema`,
+- [x] **F-3 — `schemas.py` is unused.** `get_full_schema`,
   `reset_schema_cache`, and `JsonBody` have no call sites, so the intended
   OpenAPI full-row response schema is never generated (routes register raw view
   callables with no `response=`). Either wire `get_full_schema` into
   `router.add_api_operation(..., response=...)`, or delete the module.
+  Resolved: `get_full_schema` is wired into the GET operation's `response=` in
+  `router.py` (documents the full-row list shape; runtime output is unaffected
+  since generated views return `HttpResponse` directly). `reset_schema_cache`
+  is called from `reset_registry()`. `JsonBody` (no call sites) was removed.
 
 - [ ] **F-4 — `columns` reserved param is a no-op.** `parsing.RESERVED_PARAMS`
   reserves `columns` but nothing implements PostgREST's insert column

--- a/backend/ninja_postgrest/README.md
+++ b/backend/ninja_postgrest/README.md
@@ -1,0 +1,132 @@
+# ninja_postgrest
+
+A reusable Django app that builds a [Django-Ninja](https://django-ninja.dev/)
+router exposing [PostgREST](https://postgrest.org)-compatible REST endpoints for
+a configured set of models. It respects **django-guardian** object-level
+permissions and plugs into **django-ninja** authentication.
+
+The app is self-contained so it can later be split into its own pip package.
+
+## Installation / wiring
+
+1. Add the app to `INSTALLED_APPS`:
+
+   ```python
+   INSTALLED_APPS = [..., "guardian", "ninja_postgrest", ...]
+   ```
+
+2. Configure the tables (see below) via `NINJA_POSTGREST` in settings.
+
+3. Mount the router on your `NinjaAPI`:
+
+   ```python
+   from ninja_postgrest import build_router
+
+   api.add_router("/pg/", build_router())
+   ```
+
+   Tables are then served under `/<api-prefix>/pg/<table>`.
+
+## Configuration
+
+```python
+NINJA_POSTGREST = {
+    # Default django-ninja auth applied to every table (import path, callable,
+    # instance, or list). Omit / set to None for no authentication.
+    "DEFAULT_AUTH": "ninja.security.django_auth",
+
+    # Default permission strategy: "guardian" | "model" | "open".
+    "DEFAULT_PERMISSIONS": "guardian",
+
+    # Hard cap on rows returned per request.
+    "MAX_LIMIT": 1000,
+    "DEFAULT_LIMIT": None,
+
+    "TABLES": {
+        # Shorthand: table name -> "app_label.ModelName".
+        "pipelines": "pipelines.Pipeline",
+
+        # Full form.
+        "datasets": {
+            "model": "datasets.Dataset",            # dotted path or model class
+            "operations": ["list", "read", "create", "update", "delete"],
+            "fields": [...],                        # exposed columns (default: all)
+            "filterable": [...],                    # default: fields
+            "orderable": [...],                     # default: fields
+            "writable": [...],                      # accepted on write (default: editable, non-pk)
+            "embeddable": ["configs", "pipeline"],  # relations allowed in select (default: none)
+            "pk": "id",                             # single-object lookup field
+            "auth": "...",                          # per-table auth override
+            "permissions": "guardian",              # per-table strategy override
+            "permission_map": {                     # per-action permission codenames
+                "list": "datasets.view_dataset",
+                "create": "datasets.add_dataset",
+                "update": "datasets.change_dataset",
+                "delete": "datasets.delete_dataset",
+            },
+        },
+    },
+}
+```
+
+Foreign keys are exposed as their scalar `*_id` column (e.g. `pipeline_id`) for
+fields/filtering/ordering, while the relationship name (`pipeline`) is used for
+embedding — matching PostgREST conventions.
+
+## Endpoint contract
+
+| Verb | Behaviour |
+|------|-----------|
+| `GET /pg/{t}` | List. Supports `select`, horizontal filters, `order`, `limit`/`offset` (and `Range`). `Accept: application/vnd.pgrst.object+json` returns a single object (406 unless exactly one row). `Prefer: count=exact` adds the exact total to `Content-Range`. |
+| `POST /pg/{t}` | Insert one object or an array. `Prefer: return=representation` returns the created rows (201). |
+| `PATCH /pg/{t}` | Update rows matching the filters with the JSON body. Returns rows with `Prefer: return=representation`. |
+| `DELETE /pg/{t}` | Delete rows matching the filters. Returns rows with `Prefer: return=representation`. |
+
+### Filtering operators
+
+`?col=op.value`, optionally `not.` prefixed, combined with `&` (AND) or
+`or=(…)` / `and=(…)`:
+
+`eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `like`, `ilike`, `match`, `imatch`,
+`in`, `is`, `isdistinct`, `cs`, `cd`, `ov`, `fts`/`plfts`/`phfts`/`wfts`.
+
+### select / embedding
+
+`?select=col,alias:col,col::cast,json->>path,relation(col,...)`. Embeds use
+`select_related` for forward FK/O2O and a permission-filtered `prefetch_related`
+for reverse-FK/M2M.
+
+A relation may only be embedded when it is listed in `embeddable` **and** its
+related model is itself a registered table. Embedding a relation whose model is
+not registered is denied with a 400 — there is no permission policy under which
+to expose it.
+
+## Permissions
+
+- **guardian** (default): lists/reads filtered via
+  `get_objects_for_user(view_*)`; updates/deletes restricted to objects the user
+  may `change`/`delete`; creates require the model-level `add` permission.
+- **model**: plain `user.has_perm('app.view_model')`, no per-object filtering.
+- **open**: no permission checks (ninja `auth` still applies).
+
+## Known limitations (v1)
+
+- **RPC** (`POST /rpc/{fn}`) is not implemented.
+- Embeds are restricted to relations whose model is a registered table (others
+  are denied). **Forward** (FK/O2O) embeds of registered models are not
+  additionally permission-filtered; only reverse-FK/M2M embeds are. The parent
+  row is already authorized.
+- **JSON-path filtering** (`config->>x=eq.y`) is rejected with a 400; JSON paths
+  are supported in `select` only.
+- Full-text search and array/range operators require a PostgreSQL backend.
+- FK disambiguation (`relation!fk(...)`) is not supported.
+
+## Tests
+
+```bash
+docker compose exec backend pixi run -e dev pytest ninja_postgrest/tests
+```
+
+Integration tests additionally validate the endpoints through the standard
+[`postgrest`](https://pypi.org/project/postgrest/) client library against a live
+server.

--- a/backend/ninja_postgrest/README.md
+++ b/backend/ninja_postgrest/README.md
@@ -80,7 +80,7 @@ embedding — matching PostgREST conventions.
 | Verb | Behaviour |
 |------|-----------|
 | `GET /pg/{t}` | List. Supports `select`, horizontal filters, `order`, `limit`/`offset` (and `Range`). `Accept: application/vnd.pgrst.object+json` returns a single object (406 unless exactly one row). `Prefer: count=exact` adds the exact total to `Content-Range`. |
-| `POST /pg/{t}` | Insert one object or an array; the response is always an array (201), unless the singular media type is requested. `Prefer: return=representation` returns the created rows. Sets a `Location` header (PK filter of the created row(s)). Upserts via `Prefer: resolution=…` + `?on_conflict=…` (see below). `?columns=col[,col2]` restricts which body keys are inserted (see below). |
+| `POST /pg/{t}` | Insert one object or an array; the response is always an array (201), unless the singular media type is requested. `Prefer: return=representation` returns the created rows; if the singular media type is also requested, a bulk insert 406s and the whole insert rolls back. Sets a `Location` header (PK filter of the created row(s)). Upserts via `Prefer: resolution=…` + `?on_conflict=…` (see below). `?columns=col[,col2]` restricts which body keys are inserted (see below). |
 | `PATCH /pg/{t}` | Update rows matching the filters with the JSON body. Returns rows with `Prefer: return=representation`; when a representation is requested, honours the singular media type, returning 406 unless exactly one row was updated (the update rolls back). |
 | `DELETE /pg/{t}` | Delete rows matching the filters. Returns rows with `Prefer: return=representation`; when a representation is requested, honours the singular media type, returning 406 unless exactly one row matched (nothing is deleted). |
 

--- a/backend/ninja_postgrest/README.md
+++ b/backend/ninja_postgrest/README.md
@@ -78,7 +78,7 @@ embedding — matching PostgREST conventions.
 | Verb | Behaviour |
 |------|-----------|
 | `GET /pg/{t}` | List. Supports `select`, horizontal filters, `order`, `limit`/`offset` (and `Range`). `Accept: application/vnd.pgrst.object+json` returns a single object (406 unless exactly one row). `Prefer: count=exact` adds the exact total to `Content-Range`. |
-| `POST /pg/{t}` | Insert one object or an array. `Prefer: return=representation` returns the created rows (201). |
+| `POST /pg/{t}` | Insert one object or an array; the response is always an array (201), unless the singular media type is requested. `Prefer: return=representation` returns the created rows. Upserts via `Prefer: resolution=…` + `?on_conflict=…` (see below). |
 | `PATCH /pg/{t}` | Update rows matching the filters with the JSON body. Returns rows with `Prefer: return=representation`. |
 | `DELETE /pg/{t}` | Delete rows matching the filters. Returns rows with `Prefer: return=representation`. |
 
@@ -89,6 +89,10 @@ embedding — matching PostgREST conventions.
 
 `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `like`, `ilike`, `match`, `imatch`,
 `in`, `is`, `isdistinct`, `cs`, `cd`, `ov`, `fts`/`plfts`/`phfts`/`wfts`.
+
+Columns referenced inside `or=(…)` / `and=(…)` groups must be `filterable`,
+exactly like plain filters — a logical group cannot reach a column that a
+horizontal filter cannot.
 
 ### select / embedding
 
@@ -101,11 +105,27 @@ related model is itself a registered table. Embedding a relation whose model is
 not registered is denied with a 400 — there is no permission policy under which
 to expose it.
 
+### Upsert
+
+`POST` with `Prefer: resolution=merge-duplicates` (or `ignore-duplicates`) and
+`?on_conflict=col[,col2]` inserts new rows and, on a conflict against the named
+column(s):
+
+- `merge-duplicates` updates the existing row from the remaining body columns;
+- `ignore-duplicates` leaves the existing row untouched (and returns it
+  unchanged in the representation).
+
+Without an `on_conflict` target the request degrades to a plain insert (matching
+PostgREST when no conflict target can be inferred). Inserting a new row requires
+the model-level `add` permission; updating a conflicting row additionally
+requires `change` on that row.
+
 ## Permissions
 
 - **guardian** (default): lists/reads filtered via
   `get_objects_for_user(view_*)`; updates/deletes restricted to objects the user
-  may `change`/`delete`; creates require the model-level `add` permission.
+  may `change`/`delete`; creates require the model-level `add` permission. An
+  upsert that updates a conflicting row also requires `change` on that row.
 - **model**: plain `user.has_perm('app.view_model')`, no per-object filtering.
 - **open**: no permission checks (ninja `auth` still applies).
 

--- a/backend/ninja_postgrest/README.md
+++ b/backend/ninja_postgrest/README.md
@@ -40,6 +40,8 @@ NINJA_POSTGREST = {
 
     # Hard cap on rows returned per request.
     "MAX_LIMIT": 1000,
+    # Default page size used when a request gives no `limit`/`Range` (still
+    # capped by MAX_LIMIT). None means no default: fall back to MAX_LIMIT.
     "DEFAULT_LIMIT": None,
 
     "TABLES": {

--- a/backend/ninja_postgrest/README.md
+++ b/backend/ninja_postgrest/README.md
@@ -80,7 +80,7 @@ embedding — matching PostgREST conventions.
 | Verb | Behaviour |
 |------|-----------|
 | `GET /pg/{t}` | List. Supports `select`, horizontal filters, `order`, `limit`/`offset` (and `Range`). `Accept: application/vnd.pgrst.object+json` returns a single object (406 unless exactly one row). `Prefer: count=exact` adds the exact total to `Content-Range`. |
-| `POST /pg/{t}` | Insert one object or an array; the response is always an array (201), unless the singular media type is requested. `Prefer: return=representation` returns the created rows. Upserts via `Prefer: resolution=…` + `?on_conflict=…` (see below). |
+| `POST /pg/{t}` | Insert one object or an array; the response is always an array (201), unless the singular media type is requested. `Prefer: return=representation` returns the created rows. Upserts via `Prefer: resolution=…` + `?on_conflict=…` (see below). `?columns=col[,col2]` restricts which body keys are inserted (see below). |
 | `PATCH /pg/{t}` | Update rows matching the filters with the JSON body. Returns rows with `Prefer: return=representation`. |
 | `DELETE /pg/{t}` | Delete rows matching the filters. Returns rows with `Prefer: return=representation`. |
 
@@ -121,6 +121,14 @@ Without an `on_conflict` target the request degrades to a plain insert (matching
 PostgREST when no conflict target can be inferred). Inserting a new row requires
 the model-level `add` permission; updating a conflicting row additionally
 requires `change` on that row.
+
+### `columns` (insert column restriction)
+
+`POST ...?columns=col[,col2]` restricts which body keys are considered on
+insert: keys not listed are ignored (dropped, or defaulted for unlisted
+values) rather than rejected. This applies to both plain inserts and upserts.
+A listed column must still be `writable`; an unknown/non-writable column in
+`columns` is a 400.
 
 ## Permissions
 

--- a/backend/ninja_postgrest/README.md
+++ b/backend/ninja_postgrest/README.md
@@ -80,9 +80,9 @@ embedding — matching PostgREST conventions.
 | Verb | Behaviour |
 |------|-----------|
 | `GET /pg/{t}` | List. Supports `select`, horizontal filters, `order`, `limit`/`offset` (and `Range`). `Accept: application/vnd.pgrst.object+json` returns a single object (406 unless exactly one row). `Prefer: count=exact` adds the exact total to `Content-Range`. |
-| `POST /pg/{t}` | Insert one object or an array; the response is always an array (201), unless the singular media type is requested. `Prefer: return=representation` returns the created rows. Upserts via `Prefer: resolution=…` + `?on_conflict=…` (see below). `?columns=col[,col2]` restricts which body keys are inserted (see below). |
-| `PATCH /pg/{t}` | Update rows matching the filters with the JSON body. Returns rows with `Prefer: return=representation`. |
-| `DELETE /pg/{t}` | Delete rows matching the filters. Returns rows with `Prefer: return=representation`. |
+| `POST /pg/{t}` | Insert one object or an array; the response is always an array (201), unless the singular media type is requested. `Prefer: return=representation` returns the created rows. Sets a `Location` header (PK filter of the created row(s)). Upserts via `Prefer: resolution=…` + `?on_conflict=…` (see below). `?columns=col[,col2]` restricts which body keys are inserted (see below). |
+| `PATCH /pg/{t}` | Update rows matching the filters with the JSON body. Returns rows with `Prefer: return=representation`; when a representation is requested, honours the singular media type, returning 406 unless exactly one row was updated (the update rolls back). |
+| `DELETE /pg/{t}` | Delete rows matching the filters. Returns rows with `Prefer: return=representation`; when a representation is requested, honours the singular media type, returning 406 unless exactly one row matched (nothing is deleted). |
 
 ### Filtering operators
 

--- a/backend/ninja_postgrest/__init__.py
+++ b/backend/ninja_postgrest/__init__.py
@@ -1,0 +1,33 @@
+"""ninja_postgrest — PostgREST-compatible endpoints for Django-Ninja.
+
+Given a ``NINJA_POSTGREST`` settings dict that maps table names to Django models,
+this app builds a Django-Ninja :class:`~ninja.Router` exposing PostgREST-style
+REST endpoints (horizontal/vertical filtering, ordering, pagination, CRUD and
+resource embedding). It respects django-guardian object-level permissions and
+django-ninja authentication mechanisms.
+
+Typical usage in a project's ``api.py``::
+
+    from ninja_postgrest import build_router
+
+    api.add_router("/pg/", build_router())
+"""
+
+from .exceptions import PostgrestError
+
+
+__all__ = ["PostgrestError", "build_router"]
+
+__version__ = "0.1.0"
+
+
+def build_router(*args, **kwargs):
+    """Build and return a Ninja ``Router`` exposing the configured tables.
+
+    Thin lazy wrapper around :func:`ninja_postgrest.router.build_router` so that
+    importing this package does not pull in Django models before the app
+    registry is ready.
+    """
+    from .router import build_router as _build_router
+
+    return _build_router(*args, **kwargs)

--- a/backend/ninja_postgrest/apps.py
+++ b/backend/ninja_postgrest/apps.py
@@ -1,0 +1,15 @@
+from django.apps import AppConfig
+
+
+class NinjaPostgrestConfig(AppConfig):
+    name = "ninja_postgrest"
+    label = "ninja_postgrest"
+    verbose_name = "Django-Ninja PostgREST"
+    default_auto_field = "django.db.models.BigAutoField"
+
+    def ready(self) -> None:
+        # Register the custom ``__like`` / ``__ilike`` lookups so the PostgREST
+        # ``like`` / ``ilike`` operators map directly onto SQL ``LIKE`` / ``ILIKE``.
+        from . import lookups  # noqa: F401  (import for side effect of registration)
+
+        lookups.register_lookups()

--- a/backend/ninja_postgrest/conf.py
+++ b/backend/ninja_postgrest/conf.py
@@ -1,0 +1,81 @@
+"""Loading and normalisation of the ``NINJA_POSTGREST`` setting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+# Sentinel distinguishing "not configured" from an explicit ``None`` (which, for
+# auth, means "no authentication required").
+UNSET = object()
+
+VALID_PERMISSION_MODES = ("guardian", "model", "open")
+
+
+def _resolve_auth(value: Any) -> Any:
+    """Resolve an auth setting into something Django-Ninja accepts.
+
+    Accepts an import-path string, a callable/instance, a list of either, or
+    ``None``. Strings are imported; lists are resolved element-wise.
+    """
+    if value is None or value is UNSET:
+        return value
+    if isinstance(value, str):
+        return import_string(value)
+    if isinstance(value, (list, tuple)):
+        return [_resolve_auth(item) for item in value]
+    return value
+
+
+@dataclass
+class GlobalConfig:
+    default_auth: Any = UNSET
+    default_permissions: str = "guardian"
+    max_limit: int = 1000
+    default_limit: int | None = None
+    tables: dict[str, Any] = field(default_factory=dict)
+
+
+def load_global_config() -> GlobalConfig:
+    """Read ``settings.NINJA_POSTGREST`` and apply defaults."""
+    raw: dict[str, Any] = getattr(settings, "NINJA_POSTGREST", {}) or {}
+
+    default_permissions = raw.get("DEFAULT_PERMISSIONS", "guardian")
+    if default_permissions not in VALID_PERMISSION_MODES:
+        msg = (
+            f"NINJA_POSTGREST['DEFAULT_PERMISSIONS'] must be one of "
+            f"{VALID_PERMISSION_MODES!r}, got {default_permissions!r}"
+        )
+        raise ValueError(msg)
+
+    return GlobalConfig(
+        default_auth=_resolve_auth(raw.get("DEFAULT_AUTH", UNSET)),
+        default_permissions=default_permissions,
+        max_limit=int(raw.get("MAX_LIMIT", 1000)),
+        default_limit=raw.get("DEFAULT_LIMIT"),
+        tables=raw.get("TABLES", {}) or {},
+    )
+
+
+def resolve_auth(value: Any) -> Any:
+    """Public wrapper around :func:`_resolve_auth` for per-table overrides."""
+    return _resolve_auth(value)
+
+
+_global_config: GlobalConfig | None = None
+
+
+def get_global_config() -> GlobalConfig:
+    """Return the (cached) global config."""
+    global _global_config
+    if _global_config is None:
+        _global_config = load_global_config()
+    return _global_config
+
+
+def reset_global_config() -> None:
+    global _global_config
+    _global_config = None

--- a/backend/ninja_postgrest/conf.py
+++ b/backend/ninja_postgrest/conf.py
@@ -2,17 +2,26 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 from django.conf import settings
 from django.utils.module_loading import import_string
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-# Sentinel distinguishing "not configured" from an explicit ``None`` (which, for
-# auth, means "no authentication required").
-UNSET = object()
+Operation = Literal["list", "read", "create", "update", "delete"]
+PermissionMode = Literal["guardian", "model", "open"]
 
-VALID_PERMISSION_MODES = ("guardian", "model", "open")
+
+class _Unset:
+    """Sentinel distinguishing "not configured" from an explicit ``None``.
+
+    An explicit ``None`` tells Django-Ninja that no authentication is required;
+    ``UNSET`` means the field was never configured and nothing is passed.
+    """
+
+
+# Module-level singleton imported by registry.py
+UNSET: Any = _Unset()
 
 
 def _resolve_auth(value: Any) -> Any:
@@ -21,7 +30,7 @@ def _resolve_auth(value: Any) -> Any:
     Accepts an import-path string, a callable/instance, a list of either, or
     ``None``. Strings are imported; lists are resolved element-wise.
     """
-    if value is None or value is UNSET:
+    if value is None or isinstance(value, _Unset):
         return value
     if isinstance(value, str):
         return import_string(value)
@@ -30,33 +39,74 @@ def _resolve_auth(value: Any) -> Any:
     return value
 
 
-@dataclass
-class GlobalConfig:
+class TableInputConfig(BaseModel):
+    """Raw per-table settings from ``NINJA_POSTGREST['TABLES']``.
+
+    Field lists (``fields``, ``filterable``, ``orderable``, ``writable``) are
+    ``None`` by default, meaning "inherit the model-derived default" — the
+    registry resolves the actual values once the Django model is available.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    model: Any  # "app_label.ModelName" or a Model subclass — resolved by registry
+    fields: list[str] | None = None
+    filterable: list[str] | None = None
+    orderable: list[str] | None = None
+    writable: list[str] | None = None
+    embeddable: list[str] = Field(default_factory=list)
+    operations: list[Operation] | None = None
+    permissions: PermissionMode | None = None
+    permission_map: dict[str, str] = Field(default_factory=dict)
+    auth: Any = UNSET
+    pk: str | None = None
+
+    @field_validator("auth", mode="before")
+    @classmethod
+    def resolve_auth_strings(cls, v: Any) -> Any:
+        return _resolve_auth(v)
+
+
+class GlobalConfig(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     default_auth: Any = UNSET
-    default_permissions: str = "guardian"
+    default_permissions: PermissionMode = "guardian"
     max_limit: int = 1000
     default_limit: int | None = None
-    tables: dict[str, Any] = field(default_factory=dict)
+    tables: dict[str, TableInputConfig] = Field(default_factory=dict)
+
+    @field_validator("default_auth", mode="before")
+    @classmethod
+    def resolve_auth_strings(cls, v: Any) -> Any:
+        return _resolve_auth(v)
+
+    @field_validator("tables", mode="before")
+    @classmethod
+    def normalize_tables(cls, v: Any) -> dict:
+        if not v:
+            return {}
+        result = {}
+        for k, val in v.items():
+            if isinstance(val, (str, type)):
+                result[k] = {"model": val}
+            elif isinstance(val, dict):
+                result[k] = val
+            else:
+                msg = f"TABLES[{k!r}] must be a dotted model path, a Model class, or a dict"
+                raise ValueError(msg)
+        return result
 
 
 def load_global_config() -> GlobalConfig:
     """Read ``settings.NINJA_POSTGREST`` and apply defaults."""
     raw: dict[str, Any] = getattr(settings, "NINJA_POSTGREST", {}) or {}
-
-    default_permissions = raw.get("DEFAULT_PERMISSIONS", "guardian")
-    if default_permissions not in VALID_PERMISSION_MODES:
-        msg = (
-            f"NINJA_POSTGREST['DEFAULT_PERMISSIONS'] must be one of "
-            f"{VALID_PERMISSION_MODES!r}, got {default_permissions!r}"
-        )
-        raise ValueError(msg)
-
     return GlobalConfig(
-        default_auth=_resolve_auth(raw.get("DEFAULT_AUTH", UNSET)),
-        default_permissions=default_permissions,
-        max_limit=int(raw.get("MAX_LIMIT", 1000)),
+        default_auth=raw.get("DEFAULT_AUTH", UNSET),
+        default_permissions=raw.get("DEFAULT_PERMISSIONS", "guardian"),
+        max_limit=raw.get("MAX_LIMIT", 1000),
         default_limit=raw.get("DEFAULT_LIMIT"),
-        tables=raw.get("TABLES", {}) or {},
+        tables=raw.get("TABLES"),
     )
 
 

--- a/backend/ninja_postgrest/embedding.py
+++ b/backend/ninja_postgrest/embedding.py
@@ -1,0 +1,97 @@
+"""Plan related-object fetching for ``select`` embeds.
+
+A relation may only be embedded when BOTH (a) it is listed in the table's
+``embeddable`` config and (b) its related model is itself registered in
+``NINJA_POSTGREST['TABLES']``. Embedding a relation whose model is not registered
+is explicitly denied (400) — there is no policy under which to expose it.
+
+Forward relations (FK / O2O) use ``select_related``; reverse relations and M2M
+use a permission-filtered ``prefetch_related``.
+
+v1 limitation: forward (FK/O2O) embeds are NOT additionally permission-filtered
+— the parent row is already authorized and we do not hide forward-referenced
+rows. Reverse/M2M embeds ARE filtered.
+"""
+
+from __future__ import annotations
+
+from django.db.models import Prefetch, QuerySet
+
+from .exceptions import PostgrestError
+from .parsing import SelectEmbed
+from .registry import TableConfig, get_table_for_model
+
+
+def _relation_field(model, accessor: str):
+    for f in model._meta.get_fields():
+        name = f.get_accessor_name() if hasattr(f, "get_accessor_name") else f.name
+        if name == accessor or getattr(f, "name", None) == accessor:
+            return f
+    return None
+
+
+def apply_embeds(
+    qs: QuerySet,
+    table: TableConfig | None,
+    select: list | None,
+    user,
+) -> QuerySet:
+    """Attach select_related / prefetch_related derived from ``select`` embeds."""
+    if not select:
+        return qs
+
+    select_related: list[str] = []
+    prefetches: list[Prefetch] = []
+
+    for node in select:
+        if not isinstance(node, SelectEmbed):
+            continue
+
+        if table is not None and node.relation not in table.embeddable:
+            raise PostgrestError(
+                f"Relation {node.relation!r} is not embeddable on table "
+                f"{table.name!r} (allowed: {sorted(table.embeddable)})",
+                status=400,
+                code="PGRST-400",
+            )
+
+        model = qs.model
+        field = _relation_field(model, node.relation)
+        if field is None:
+            raise PostgrestError(
+                f"Unknown relation {node.relation!r} on {model.__name__}",
+                status=400,
+                code="PGRST-400",
+            )
+
+        # The related model must be a registered table, otherwise there is no
+        # permission policy under which to expose it: deny explicitly.
+        related_model = field.related_model
+        related_table = get_table_for_model(related_model)
+        if related_table is None:
+            raise PostgrestError(
+                f"Cannot embed {node.relation!r}: its model "
+                f"{related_model.__name__!r} is not a registered table",
+                status=400,
+                code="PGRST-400",
+            )
+
+        if field.many_to_one or field.one_to_one:
+            select_related.append(node.relation)
+            continue
+
+        from .permissions import filter_readable
+
+        rel_qs = filter_readable(
+            user,
+            related_table,
+            related_model._default_manager.all(),
+        )
+        rel_qs = apply_embeds(rel_qs, related_table, node.children or None, user)
+        prefetches.append(Prefetch(node.relation, queryset=rel_qs))
+
+    if select_related:
+        qs = qs.select_related(*select_related)
+    if prefetches:
+        qs = qs.prefetch_related(*prefetches)
+    return qs

--- a/backend/ninja_postgrest/exceptions.py
+++ b/backend/ninja_postgrest/exceptions.py
@@ -1,0 +1,62 @@
+"""PostgREST-compatible error type and response helpers.
+
+PostgREST returns JSON error bodies of the shape::
+
+    {"message": "...", "details": "...", "hint": "...", "code": "..."}
+
+We mirror that shape. Endpoints are wrapped with :func:`postgrest_endpoint`
+which turns a raised :class:`PostgrestError` into the appropriate JSON response,
+so the app stays self-contained and does not need to mutate the consumer's
+``NinjaAPI`` instance with exception handlers.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+
+from django.http import JsonResponse
+
+
+class PostgrestError(Exception):
+    """An error to return to the client in PostgREST's JSON error format."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: int = 400,
+        details: str | None = None,
+        hint: str | None = None,
+        code: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status = status
+        self.details = details
+        self.hint = hint
+        self.code = code
+
+    def to_dict(self) -> dict[str, str | None]:
+        return {
+            "message": self.message,
+            "details": self.details,
+            "hint": self.hint,
+            "code": self.code,
+        }
+
+    def to_response(self) -> JsonResponse:
+        return JsonResponse(self.to_dict(), status=self.status)
+
+
+def postgrest_endpoint(func: Callable) -> Callable:
+    """Wrap a view so raised :class:`PostgrestError` becomes a JSON response."""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except PostgrestError as exc:
+            return exc.to_response()
+
+    return wrapper

--- a/backend/ninja_postgrest/headers.py
+++ b/backend/ninja_postgrest/headers.py
@@ -1,0 +1,77 @@
+"""Parsing of PostgREST request headers and building the ``Content-Range``
+response header."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from django.http import HttpRequest
+
+SINGULAR_MEDIA_TYPE = "application/vnd.pgrst.object+json"
+
+
+@dataclass
+class Prefer:
+    count: str | None = None  # "exact" | "planned" | "estimated"
+    return_representation: bool = False
+    resolution: str | None = None  # "merge-duplicates" | "ignore-duplicates"
+
+
+def parse_prefer(request: HttpRequest) -> Prefer:
+    raw = request.headers.get("Prefer", "")
+    prefer = Prefer()
+    for part in raw.split(","):
+        token = part.strip()
+        if not token:
+            continue
+        key, _, value = token.partition("=")
+        key, value = key.strip(), value.strip()
+        if key == "count":
+            prefer.count = value
+        elif key == "return":
+            prefer.return_representation = value == "representation"
+        elif key == "resolution":
+            prefer.resolution = value
+    return prefer
+
+
+def wants_single_object(request: HttpRequest) -> bool:
+    """True when the client requested a singular response via Accept."""
+    return SINGULAR_MEDIA_TYPE in request.headers.get("Accept", "")
+
+
+def parse_range(request: HttpRequest) -> tuple[int | None, int | None]:
+    """Parse a ``Range: 0-9`` header into ``(offset, limit)``.
+
+    Returns ``(None, None)`` when absent or unparsable.
+    """
+    raw = request.headers.get("Range", "")
+    if not raw:
+        return None, None
+    spec = raw.split("=", 1)[-1].strip()  # tolerate "items=0-9"
+    start_s, sep, end_s = spec.partition("-")
+    if not sep:
+        return None, None
+    try:
+        start = int(start_s)
+    except ValueError:
+        return None, None
+    if not end_s:
+        return start, None
+    try:
+        end = int(end_s)
+    except ValueError:
+        return start, None
+    return start, end - start + 1
+
+
+def content_range(offset: int, returned: int, total: int | None) -> str:
+    """Build a ``Content-Range`` value like ``0-9/42`` or ``0-9/*``.
+
+    An empty page is rendered as ``*/<total>`` per PostgREST convention.
+    """
+    total_part = "*" if total is None else str(total)
+    if returned == 0:
+        return f"*/{total_part}"
+    end = offset + returned - 1
+    return f"{offset}-{end}/{total_part}"

--- a/backend/ninja_postgrest/lookups.py
+++ b/backend/ninja_postgrest/lookups.py
@@ -1,0 +1,48 @@
+"""Custom Django lookups backing the PostgREST ``like`` / ``ilike`` operators.
+
+PostgREST's ``like`` and ``ilike`` use SQL ``LIKE``/``ILIKE`` semantics with
+``*`` standing in for ``%``. Django has no built-in lookup that exposes a raw
+``LIKE`` with caller-supplied wildcards (``__contains`` escapes them), so we
+register thin lookups that emit ``LIKE`` / ``ILIKE`` directly.
+"""
+
+from __future__ import annotations
+
+from django.db.models import Field, Lookup
+
+
+class Like(Lookup):
+    lookup_name = "like"
+
+    def as_sql(self, compiler, connection):
+        lhs, lhs_params = self.process_lhs(compiler, connection)
+        rhs, rhs_params = self.process_rhs(compiler, connection)
+        return f"{lhs} LIKE {rhs}", (*lhs_params, *rhs_params)
+
+
+class ILike(Lookup):
+    lookup_name = "ilike"
+
+    def as_sql(self, compiler, connection):
+        lhs, lhs_params = self.process_lhs(compiler, connection)
+        rhs, rhs_params = self.process_rhs(compiler, connection)
+        # SQLite has no ILIKE; fall back to a case-insensitive LIKE there.
+        if connection.vendor == "sqlite":
+            return f"{lhs} LIKE {rhs}", (*lhs_params, *rhs_params)
+        return f"{lhs} ILIKE {rhs}", (*lhs_params, *rhs_params)
+
+
+_registered = False
+
+
+def register_lookups() -> None:
+    """Register the lookups on ``Field`` so they apply to every field type.
+
+    Idempotent: safe to call more than once (e.g. from ``AppConfig.ready``).
+    """
+    global _registered
+    if _registered:
+        return
+    Field.register_lookup(Like)
+    Field.register_lookup(ILike)
+    _registered = True

--- a/backend/ninja_postgrest/operators.py
+++ b/backend/ninja_postgrest/operators.py
@@ -1,0 +1,163 @@
+"""Translation of PostgREST horizontal-filter operators into Django ``Q`` objects.
+
+A filter arrives as ``?column=operator.value`` (optionally ``not.`` prefixed),
+e.g. ``?age=gte.18``, ``?name=ilike.*foo*``, ``?id=in.(1,2,3)``,
+``?active=is.true``, ``?tags=cs.{a,b}``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.contrib.postgres.search import SearchQuery
+from django.db.models import Q
+
+from .exceptions import PostgrestError
+
+# Operators that map directly onto a Django field lookup, taking the value as-is.
+SIMPLE_LOOKUPS: dict[str, str] = {
+    "eq": "exact",
+    "neq": "exact",  # negated below
+    "gt": "gt",
+    "gte": "gte",
+    "lt": "lt",
+    "lte": "lte",
+    "like": "like",
+    "ilike": "ilike",
+    "match": "regex",
+    "imatch": "iregex",
+}
+
+# Array / range operators (PostgreSQL-specific; best-effort).
+SET_LOOKUPS: dict[str, str] = {
+    "cs": "contains",
+    "cd": "contained_by",
+    "ov": "overlap",
+}
+
+FTS_OPERATORS = {"fts", "plfts", "phfts", "wfts"}
+
+# PostgREST search-type -> Django SearchQuery ``search_type``.
+FTS_SEARCH_TYPE = {
+    "fts": "plain",
+    "plfts": "plain",
+    "phfts": "phrase",
+    "wfts": "websearch",
+}
+
+
+def _split_op(token: str) -> tuple[bool, str, str | None, str]:
+    """Split an operator token into ``(negate, op, modifier, value)``.
+
+    Examples::
+
+        "eq.foo"          -> (False, "eq", None, "foo")
+        "not.ilike.*x*"   -> (True, "ilike", None, "*x*")
+        "fts(english).cat"-> (False, "fts", "english", "cat")
+        "is.null"         -> (False, "is", None, "null")
+    """
+    negate = False
+    if token.startswith("not."):
+        negate = True
+        token = token[4:]
+
+    op_part, sep, value = token.partition(".")
+    if not sep:
+        raise PostgrestError(
+            f"Malformed filter operator: {token!r}",
+            code="PGRST-100",
+            hint="Expected the form 'operator.value', e.g. 'eq.123'.",
+        )
+
+    modifier: str | None = None
+    if "(" in op_part and op_part.endswith(")"):
+        op_part, _, mod = op_part[:-1].partition("(")
+        modifier = mod
+
+    return negate, op_part, modifier, value
+
+
+def _parse_list(value: str) -> list[str]:
+    """Parse a PostgREST list literal ``(a,b,c)`` or ``{a,b,c}``."""
+    inner = value.strip()
+    if inner and inner[0] in "({" and inner[-1] in ")}":
+        inner = inner[1:-1]
+    if not inner:
+        return []
+    # Minimal handling of double-quoted members containing commas.
+    out: list[str] = []
+    buf = ""
+    in_quote = False
+    for ch in inner:
+        if ch == '"':
+            in_quote = not in_quote
+            continue
+        if ch == "," and not in_quote:
+            out.append(buf)
+            buf = ""
+            continue
+        buf += ch
+    out.append(buf)
+    return [item.strip() for item in out]
+
+
+def _coerce_is_value(value: str) -> Any:
+    mapping = {"null": None, "true": True, "false": False, "unknown": None}
+    key = value.lower()
+    if key not in mapping:
+        raise PostgrestError(
+            f"Invalid 'is' value: {value!r}",
+            code="PGRST-100",
+            hint="Use is.null, is.true, is.false or is.unknown.",
+        )
+    return mapping[key]
+
+
+def build_q(column: str, token: str) -> Q:
+    """Build a ``Q`` object for a single ``column=token`` filter."""
+    negate, op, modifier, value = _split_op(token)
+    q = _build_q_inner(column, op, modifier, value)
+    return ~q if negate else q
+
+
+def _build_q_inner(column: str, op: str, modifier: str | None, value: str) -> Q:
+    if op in SIMPLE_LOOKUPS:
+        lookup = SIMPLE_LOOKUPS[op]
+        parsed: Any = value
+        if op in ("like", "ilike"):
+            parsed = value.replace("*", "%")
+        q = Q(**{f"{column}__{lookup}": parsed})
+        return ~q if op == "neq" else q
+
+    if op == "in":
+        return Q(**{f"{column}__in": _parse_list(value)})
+
+    if op == "is":
+        coerced = _coerce_is_value(value)
+        if coerced is None:
+            return Q(**{f"{column}__isnull": True})
+        return Q(**{f"{column}__exact": coerced})
+
+    if op == "isdistinct":
+        # DISTINCT FROM: differs from the value, including across NULLs.
+        return ~Q(**{f"{column}__exact": value})
+
+    if op in SET_LOOKUPS:
+        return Q(**{f"{column}__{SET_LOOKUPS[op]}": _parse_list(value)})
+
+    if op in FTS_OPERATORS:
+        # ``field__search`` accepts a SearchQuery directly, generating
+        # ``to_tsvector(field) @@ <query>`` on PostgreSQL. Best-effort: requires
+        # a PostgreSQL backend (no-op/raises on SQLite).
+        query = SearchQuery(
+            value,
+            config=modifier or None,
+            search_type=FTS_SEARCH_TYPE[op],
+        )
+        return Q(**{f"{column}__search": query})
+
+    raise PostgrestError(
+        f"Unknown operator {op!r}",
+        code="PGRST-100",
+        hint=f"Supported: {sorted(set(SIMPLE_LOOKUPS) | set(SET_LOOKUPS) | {'in', 'is', 'isdistinct'} | FTS_OPERATORS)}",
+    )

--- a/backend/ninja_postgrest/operators.py
+++ b/backend/ninja_postgrest/operators.py
@@ -139,8 +139,9 @@ def _build_q_inner(column: str, op: str, modifier: str | None, value: str) -> Q:
         return Q(**{f"{column}__exact": coerced})
 
     if op == "isdistinct":
-        # DISTINCT FROM: differs from the value, including across NULLs.
-        return ~Q(**{f"{column}__exact": value})
+        # IS DISTINCT FROM is NULL-safe: a NULL row is distinct from any
+        # non-null value, so include NULL rows that ~exact would drop.
+        return ~Q(**{f"{column}__exact": value}) | Q(**{f"{column}__isnull": True})
 
     if op in SET_LOOKUPS:
         return Q(**{f"{column}__{SET_LOOKUPS[op]}": _parse_list(value)})

--- a/backend/ninja_postgrest/operators.py
+++ b/backend/ninja_postgrest/operators.py
@@ -65,7 +65,7 @@ def _split_op(token: str) -> tuple[bool, str, str | None, str]:
     if not sep:
         raise PostgrestError(
             f"Malformed filter operator: {token!r}",
-            code="PGRST-100",
+            code="PGRST100",
             hint="Expected the form 'operator.value', e.g. 'eq.123'.",
         )
 
@@ -107,7 +107,7 @@ def _coerce_is_value(value: str) -> Any:
     if key not in mapping:
         raise PostgrestError(
             f"Invalid 'is' value: {value!r}",
-            code="PGRST-100",
+            code="PGRST100",
             hint="Use is.null, is.true, is.false or is.unknown.",
         )
     return mapping[key]
@@ -159,6 +159,6 @@ def _build_q_inner(column: str, op: str, modifier: str | None, value: str) -> Q:
 
     raise PostgrestError(
         f"Unknown operator {op!r}",
-        code="PGRST-100",
+        code="PGRST100",
         hint=f"Supported: {sorted(set(SIMPLE_LOOKUPS) | set(SET_LOOKUPS) | {'in', 'is', 'isdistinct'} | FTS_OPERATORS)}",
     )

--- a/backend/ninja_postgrest/parsing.py
+++ b/backend/ninja_postgrest/parsing.py
@@ -1,0 +1,366 @@
+"""Parse a PostgREST query string into structured pieces.
+
+Produces:
+- a combined ``Q`` object from horizontal filters (incl. ``or=()`` / ``and=()``),
+- a ``select`` tree (vertical filtering + embeds),
+- an ordering spec,
+- ``limit`` / ``offset``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from django.db.models import Q
+from django.http import HttpRequest
+
+from .exceptions import PostgrestError
+from .operators import build_q
+
+RESERVED_PARAMS = {
+    "select",
+    "order",
+    "limit",
+    "offset",
+    "and",
+    "or",
+    "on_conflict",
+    "columns",
+}
+
+
+# --------------------------------------------------------------------------- #
+# Generic paren-aware splitting
+# --------------------------------------------------------------------------- #
+def split_top_level(s: str, sep: str = ",") -> list[str]:
+    """Split ``s`` on ``sep`` ignoring separators nested in (), [] or {}."""
+    parts: list[str] = []
+    depth = 0
+    buf = ""
+    for ch in s:
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+        if ch == sep and depth == 0:
+            parts.append(buf)
+            buf = ""
+        else:
+            buf += ch
+    if buf or parts:
+        parts.append(buf)
+    return parts
+
+
+# --------------------------------------------------------------------------- #
+# select tree
+# --------------------------------------------------------------------------- #
+@dataclass
+class SelectField:
+    column: str  # base column name (model field)
+    alias: str | None = None  # output key override
+    cast: str | None = None  # PostgREST ::type cast (best-effort, informational)
+    json_path: list[str] = field(default_factory=list)  # ->/->> path segments
+    json_text: bool = False  # final segment used ->> (text) vs -> (json)
+
+    @property
+    def output_key(self) -> str:
+        if self.alias:
+            return self.alias
+        if self.json_path:
+            return self.json_path[-1]
+        return self.column
+
+
+@dataclass
+class SelectEmbed:
+    relation: str  # related accessor name on the model
+    alias: str | None = None
+    children: list = field(default_factory=list)  # list[SelectField | SelectEmbed]
+
+    @property
+    def output_key(self) -> str:
+        return self.alias or self.relation
+
+
+def _parse_json_path(rest: str) -> tuple[list[str], bool]:
+    """Parse the ``->a->>b`` portion after a base column."""
+    segments: list[str] = []
+    json_text = False
+    # rest looks like "->a->b->>c"
+    chunk = rest
+    while chunk.startswith("->"):
+        if chunk.startswith("->>"):
+            json_text = True
+            chunk = chunk[3:]
+        else:
+            json_text = False
+            chunk = chunk[2:]
+        # read until the next "->" or end
+        nxt = chunk.find("->")
+        seg = chunk if nxt == -1 else chunk[:nxt]
+        segments.append(seg.strip().strip("'\""))
+        chunk = "" if nxt == -1 else chunk[nxt:]
+    return segments, json_text
+
+
+def _parse_select_field(item: str) -> SelectField:
+    alias = None
+    if ":" in item and "::" not in item.split(":", 1)[0]:
+        # alias:col  (avoid splitting the ::cast operator)
+        maybe_alias, _, rest = item.partition(":")
+        if rest and not rest.startswith(":"):
+            alias = maybe_alias.strip()
+            item = rest.strip()
+
+    cast = None
+    if "::" in item:
+        item, _, cast = item.partition("::")
+        cast = cast.strip()
+
+    column = item
+    json_path: list[str] = []
+    json_text = False
+    if "->" in item:
+        column, sep, rest = item.partition("->")
+        json_path, json_text = _parse_json_path(sep + rest)
+
+    return SelectField(
+        column=column.strip(),
+        alias=alias,
+        cast=cast,
+        json_path=json_path,
+        json_text=json_text,
+    )
+
+
+def parse_select(value: str) -> list:
+    """Parse a ``select`` value into a list of SelectField / SelectEmbed nodes."""
+    nodes: list = []
+    for raw in split_top_level(value):
+        item = raw.strip()
+        if not item:
+            continue
+        if item == "*":
+            continue  # "all fields" is the default; an explicit * is a no-op marker
+        if "(" in item and item.endswith(")"):
+            head, _, inner = item.partition("(")
+            inner = inner[:-1]  # drop trailing ")"
+            alias = None
+            relation = head.strip()
+            if ":" in relation:
+                alias, _, relation = relation.partition(":")
+                alias = alias.strip()
+                relation = relation.strip()
+            nodes.append(
+                SelectEmbed(
+                    relation=relation,
+                    alias=alias,
+                    children=parse_select(inner),
+                ),
+            )
+        else:
+            nodes.append(_parse_select_field(item))
+    return nodes
+
+
+# --------------------------------------------------------------------------- #
+# order
+# --------------------------------------------------------------------------- #
+@dataclass
+class OrderTerm:
+    column: str
+    descending: bool = False
+    nulls: str | None = None  # "first" | "last" | None
+
+
+def parse_order(value: str) -> list[OrderTerm]:
+    terms: list[OrderTerm] = []
+    for raw in split_top_level(value):
+        item = raw.strip()
+        if not item:
+            continue
+        parts = item.split(".")
+        column = parts[0]
+        descending = False
+        nulls = None
+        directions = {"asc": False, "desc": True}
+        nulls_tokens = {"nullsfirst": "first", "nullslast": "last"}
+        for token in parts[1:]:
+            if token in directions:
+                descending = directions[token]
+            elif token in nulls_tokens:
+                nulls = nulls_tokens[token]
+            else:
+                raise PostgrestError(
+                    f"Invalid order token {token!r} in {item!r}",
+                    code="PGRST-100",
+                )
+        terms.append(OrderTerm(column=column, descending=descending, nulls=nulls))
+    return terms
+
+
+def order_to_orm(terms: list[OrderTerm]) -> list:
+    """Convert OrderTerms into ``OrderBy`` expressions / field strings."""
+    from django.db.models import F
+
+    expressions = []
+    for t in terms:
+        # ``nulls_first`` / ``nulls_last`` must be True or None (never False).
+        nulls_kwargs: dict = {}
+        if t.nulls == "first":
+            nulls_kwargs["nulls_first"] = True
+        elif t.nulls == "last":
+            nulls_kwargs["nulls_last"] = True
+        f = F(t.column)
+        expr = f.desc(**nulls_kwargs) if t.descending else f.asc(**nulls_kwargs)
+        expressions.append(expr)
+    return expressions
+
+
+# --------------------------------------------------------------------------- #
+# logical or/and
+# --------------------------------------------------------------------------- #
+def _parse_logical(value: str, combinator: str) -> Q:
+    """Parse the body of ``or=(...)`` / ``and=(...)`` into a combined ``Q``."""
+    inner = value.strip()
+    if inner.startswith("(") and inner.endswith(")"):
+        inner = inner[1:-1]
+    combined: Q | None = None
+    for raw in split_top_level(inner):
+        cond = raw.strip()
+        if not cond:
+            continue
+        q = _parse_condition(cond)
+        if combined is None:
+            combined = q
+        elif combinator == "or":
+            combined |= q
+        else:
+            combined &= q
+    return combined if combined is not None else Q()
+
+
+def _parse_condition(cond: str) -> Q:
+    """Parse one condition inside a logical group.
+
+    Either a nested ``and(...)`` / ``or(...)`` / ``not.and(...)`` group, or a
+    leaf ``column.operator.value``.
+    """
+    negate = False
+    if cond.startswith("not."):
+        negate = True
+        cond = cond[4:]
+
+    if cond.startswith(("and(", "or(")):
+        kind = "and" if cond.startswith("and(") else "or"
+        body = cond[len(kind) :]
+        q = _parse_logical(body, kind)
+        return ~q if negate else q
+
+    column, _, token = cond.partition(".")
+    if not token:
+        raise PostgrestError(f"Malformed condition {cond!r}", code="PGRST-100")
+    q = build_q(column, ("not." + token) if negate else token)
+    return q
+
+
+# --------------------------------------------------------------------------- #
+# top-level entry point
+# --------------------------------------------------------------------------- #
+@dataclass
+class ParsedQuery:
+    q: Q
+    select: list | None  # None => all configured fields
+    order: list  # list of ORM order expressions
+    order_terms: list[OrderTerm]
+    limit: int | None
+    offset: int
+
+
+def _base_column(name: str) -> str:
+    """Strip ``->`` json paths and ``::`` casts to get the model field name."""
+    return name.split("->", 1)[0].split("::", 1)[0]
+
+
+def parse_request(request: HttpRequest, table) -> ParsedQuery:
+    """Parse a request's GET params against a ``TableConfig``."""
+    from .headers import parse_range
+
+    params = request.GET
+    q = Q()
+
+    # Horizontal filters (column=op.value), allowing repeats.
+    for key in params:
+        if key in RESERVED_PARAMS:
+            continue
+        if "->" in key:
+            raise PostgrestError(
+                f"JSON-path filtering ({key!r}) is not supported yet",
+                status=400,
+                code="PGRST-400",
+            )
+        base = _base_column(key)
+        if base not in table.filterable:
+            raise PostgrestError(
+                f"Column {base!r} is not filterable on table {table.name!r}",
+                status=400,
+                code="PGRST-400",
+            )
+        for token in params.getlist(key):
+            q &= build_q(key, token)
+
+    # Logical groups.
+    for combinator in ("and", "or"):
+        if combinator in params:
+            for value in params.getlist(combinator):
+                q &= _parse_logical(value, combinator)
+
+    # select
+    select = None
+    if "select" in params:
+        select = parse_select(params["select"])
+
+    # order
+    order_terms: list[OrderTerm] = []
+    if "order" in params:
+        order_terms = parse_order(params["order"])
+        for t in order_terms:
+            if _base_column(t.column) not in table.orderable:
+                raise PostgrestError(
+                    f"Column {t.column!r} is not orderable on table {table.name!r}",
+                    status=400,
+                    code="PGRST-400",
+                )
+    order = order_to_orm(order_terms)
+
+    # limit / offset (query params take precedence over Range header)
+    limit: int | None = None
+    offset = 0
+    range_offset, range_limit = parse_range(request)
+    if range_offset is not None:
+        offset = range_offset
+        limit = range_limit
+    if "limit" in params:
+        limit = _int_param(params["limit"], "limit")
+    if "offset" in params:
+        offset = _int_param(params["offset"], "offset")
+
+    return ParsedQuery(
+        q=q,
+        select=select,
+        order=order,
+        order_terms=order_terms,
+        limit=limit,
+        offset=offset,
+    )
+
+
+def _int_param(value: str, name: str) -> int:
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise PostgrestError(
+            f"{name} must be an integer, got {value!r}",
+            code="PGRST-100",
+        ) from exc

--- a/backend/ninja_postgrest/parsing.py
+++ b/backend/ninja_postgrest/parsing.py
@@ -221,8 +221,14 @@ def order_to_orm(terms: list[OrderTerm]) -> list:
 # --------------------------------------------------------------------------- #
 # logical or/and
 # --------------------------------------------------------------------------- #
-def _parse_logical(value: str, combinator: str) -> Q:
-    """Parse the body of ``or=(...)`` / ``and=(...)`` into a combined ``Q``."""
+def _parse_logical(value: str, combinator: str, table=None) -> Q:
+    """Parse the body of ``or=(...)`` / ``and=(...)`` into a combined ``Q``.
+
+    When ``table`` is supplied, leaf columns are checked against its
+    ``filterable`` allowlist — the same guard applied to plain
+    ``?col=op.value`` filters — so logical groups cannot reach columns that
+    horizontal filters cannot.
+    """
     inner = value.strip()
     if inner.startswith("(") and inner.endswith(")"):
         inner = inner[1:-1]
@@ -231,7 +237,7 @@ def _parse_logical(value: str, combinator: str) -> Q:
         cond = raw.strip()
         if not cond:
             continue
-        q = _parse_condition(cond)
+        q = _parse_condition(cond, table)
         if combined is None:
             combined = q
         elif combinator == "or":
@@ -241,7 +247,7 @@ def _parse_logical(value: str, combinator: str) -> Q:
     return combined if combined is not None else Q()
 
 
-def _parse_condition(cond: str) -> Q:
+def _parse_condition(cond: str, table=None) -> Q:
     """Parse one condition inside a logical group.
 
     Either a nested ``and(...)`` / ``or(...)`` / ``not.and(...)`` group, or a
@@ -255,12 +261,20 @@ def _parse_condition(cond: str) -> Q:
     if cond.startswith(("and(", "or(")):
         kind = "and" if cond.startswith("and(") else "or"
         body = cond[len(kind) :]
-        q = _parse_logical(body, kind)
+        q = _parse_logical(body, kind, table)
         return ~q if negate else q
 
     column, _, token = cond.partition(".")
     if not token:
         raise PostgrestError(f"Malformed condition {cond!r}", code="PGRST-100")
+    if table is not None:
+        base = _base_column(column)
+        if base not in table.filterable:
+            raise PostgrestError(
+                f"Column {base!r} is not filterable on table {table.name!r}",
+                status=400,
+                code="PGRST-400",
+            )
     q = build_q(column, ("not." + token) if negate else token)
     return q
 
@@ -314,7 +328,7 @@ def parse_request(request: HttpRequest, table) -> ParsedQuery:
     for combinator in ("and", "or"):
         if combinator in params:
             for value in params.getlist(combinator):
-                q &= _parse_logical(value, combinator)
+                q &= _parse_logical(value, combinator, table)
 
     # select
     select = None

--- a/backend/ninja_postgrest/parsing.py
+++ b/backend/ninja_postgrest/parsing.py
@@ -194,7 +194,7 @@ def parse_order(value: str) -> list[OrderTerm]:
             else:
                 raise PostgrestError(
                     f"Invalid order token {token!r} in {item!r}",
-                    code="PGRST-100",
+                    code="PGRST100",
                 )
         terms.append(OrderTerm(column=column, descending=descending, nulls=nulls))
     return terms
@@ -266,7 +266,7 @@ def _parse_condition(cond: str, table=None) -> Q:
 
     column, _, token = cond.partition(".")
     if not token:
-        raise PostgrestError(f"Malformed condition {cond!r}", code="PGRST-100")
+        raise PostgrestError(f"Malformed condition {cond!r}", code="PGRST100")
     if table is not None:
         base = _base_column(column)
         if base not in table.filterable:
@@ -376,5 +376,5 @@ def _int_param(value: str, name: str) -> int:
     except ValueError as exc:
         raise PostgrestError(
             f"{name} must be an integer, got {value!r}",
-            code="PGRST-100",
+            code="PGRST100",
         ) from exc

--- a/backend/ninja_postgrest/permissions.py
+++ b/backend/ninja_postgrest/permissions.py
@@ -1,0 +1,66 @@
+"""Permission strategies layered on top of django-ninja auth.
+
+Three modes (per table, defaulting to the global ``DEFAULT_PERMISSIONS``):
+
+- ``guardian`` — object-level filtering via django-guardian. Lists/reads are
+  filtered to objects the user may ``view``; updates/deletes to objects they may
+  ``change`` / ``delete``; creates require the model-level ``add`` perm.
+- ``model`` — plain ``user.has_perm('app.view_model')`` checks, no per-object
+  filtering.
+- ``open`` — no permission checks (ninja ``auth`` still applies).
+"""
+
+from __future__ import annotations
+
+from django.db.models import QuerySet
+
+from .exceptions import PostgrestError
+from .registry import TableConfig
+
+
+def _deny(action: str, table: TableConfig) -> PostgrestError:
+    return PostgrestError(
+        f"You do not have permission to {action} on table {table.name!r}",
+        status=403,
+        code="PGRST-403",
+    )
+
+
+def filter_readable(user, table: TableConfig, qs: QuerySet) -> QuerySet:
+    """Restrict a queryset to rows the user may read."""
+    mode = table.permissions
+    if mode == "open":
+        return qs
+    perm = table.perm_codename("list")
+    if mode == "guardian":
+        from guardian.shortcuts import get_objects_for_user
+
+        return get_objects_for_user(user, perm, klass=qs, accept_global_perms=True)
+    # model mode
+    if not user.has_perm(perm):
+        return qs.none()
+    return qs
+
+
+def filter_writable(user, table: TableConfig, qs: QuerySet, action: str) -> QuerySet:
+    """Restrict a queryset to rows the user may ``update`` / ``delete``."""
+    mode = table.permissions
+    if mode == "open":
+        return qs
+    perm = table.perm_codename(action)
+    if mode == "guardian":
+        from guardian.shortcuts import get_objects_for_user
+
+        return get_objects_for_user(user, perm, klass=qs, accept_global_perms=True)
+    if not user.has_perm(perm):
+        return qs.none()
+    return qs
+
+
+def require_create(user, table: TableConfig) -> None:
+    """Raise unless the user may create rows (model-level ``add`` perm)."""
+    if table.permissions == "open":
+        return
+    perm = table.perm_codename("create")
+    if not user.has_perm(perm):
+        raise _deny("create", table)

--- a/backend/ninja_postgrest/permissions.py
+++ b/backend/ninja_postgrest/permissions.py
@@ -64,3 +64,24 @@ def require_create(user, table: TableConfig) -> None:
     perm = table.perm_codename("create")
     if not user.has_perm(perm):
         raise _deny("create", table)
+
+
+def require_change_object(user, table: TableConfig, obj) -> None:
+    """Raise unless the user may update this specific existing object.
+
+    Used by the upsert (``merge-duplicates``) path so a caller holding only the
+    model-level ``add`` permission cannot update rows it may not ``change``.
+    Mirrors :func:`filter_writable` for a single instance: object-level or
+    global ``change`` perm under ``guardian``, a plain perm under ``model``,
+    always allowed under ``open``.
+    """
+    mode = table.permissions
+    if mode == "open":
+        return
+    perm = table.perm_codename("update")
+    if mode == "guardian":
+        allowed = user.has_perm(perm) or user.has_perm(perm, obj)
+    else:
+        allowed = user.has_perm(perm)
+    if not allowed:
+        raise _deny("update", table)

--- a/backend/ninja_postgrest/query.py
+++ b/backend/ninja_postgrest/query.py
@@ -1,0 +1,34 @@
+"""Assemble a final queryset from a parsed request + permission filtering."""
+
+from __future__ import annotations
+
+from django.db.models import QuerySet
+
+from .embedding import apply_embeds
+from .parsing import ParsedQuery
+from .permissions import filter_readable
+from .registry import TableConfig
+
+
+def build_read_queryset(table: TableConfig, parsed: ParsedQuery, user) -> QuerySet:
+    """Build the queryset for a GET: permission filter, horizontal filter,
+    embeds and ordering. Slicing (limit/offset) is applied by the caller after
+    optionally counting."""
+    qs = table.model._default_manager.all()
+    qs = filter_readable(user, table, qs)
+    qs = qs.filter(parsed.q)
+    qs = apply_embeds(qs, table, parsed.select, user)
+    if parsed.order:
+        qs = qs.order_by(*parsed.order)
+    return qs
+
+
+def slice_queryset(
+    qs: QuerySet,
+    offset: int,
+    limit: int | None,
+    max_limit: int,
+) -> QuerySet:
+    """Apply offset/limit honouring the configured ``MAX_LIMIT`` cap."""
+    effective_limit = max_limit if limit is None else min(limit, max_limit)
+    return qs[offset : offset + effective_limit]

--- a/backend/ninja_postgrest/query.py
+++ b/backend/ninja_postgrest/query.py
@@ -28,7 +28,11 @@ def slice_queryset(
     offset: int,
     limit: int | None,
     max_limit: int,
+    default_limit: int | None = None,
 ) -> QuerySet:
-    """Apply offset/limit honouring the configured ``MAX_LIMIT`` cap."""
+    """Apply offset/limit. When the request gave no limit, fall back to
+    ``default_limit`` (if configured); ``max_limit`` is always the hard cap."""
+    if limit is None:
+        limit = default_limit
     effective_limit = max_limit if limit is None else min(limit, max_limit)
     return qs[offset : offset + effective_limit]

--- a/backend/ninja_postgrest/registry.py
+++ b/backend/ninja_postgrest/registry.py
@@ -1,0 +1,218 @@
+"""Table registry: turns the ``NINJA_POSTGREST['TABLES']`` mapping into
+validated :class:`TableConfig` objects keyed by the exposed table name."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from django.apps import apps
+from django.db.models import Field, Model
+
+from .conf import UNSET, GlobalConfig, load_global_config, resolve_auth
+
+ALL_OPERATIONS = ("list", "read", "create", "update", "delete")
+
+# Maps a CRUD action to the Django permission action verb used to build a
+# default permission codename (``<app_label>.<verb>_<model_name>``).
+ACTION_TO_PERM_VERB = {
+    "list": "view",
+    "read": "view",
+    "create": "add",
+    "update": "change",
+    "delete": "delete",
+}
+
+
+def _resolve_model(model_ref: Any) -> type[Model]:
+    if isinstance(model_ref, str):
+        return apps.get_model(model_ref)
+    if isinstance(model_ref, type) and issubclass(model_ref, Model):
+        return model_ref
+    msg = f"Cannot resolve model from {model_ref!r}; use 'app_label.Model' or a Model class"
+    raise TypeError(msg)
+
+
+def _concrete_field_names(model: type[Model]) -> list[str]:
+    """Exposed scalar columns: the ``attname`` (so FKs appear as ``pipeline_id``,
+    matching PostgREST's flat table columns)."""
+    return [f.attname for f in model._meta.concrete_fields]
+
+
+def _valid_field_tokens(model: type[Model]) -> set[str]:
+    """Field names accepted in config: both ``name`` and ``attname``."""
+    tokens: set[str] = set()
+    for f in model._meta.concrete_fields:
+        tokens.add(f.name)
+        tokens.add(f.attname)
+    return tokens
+
+
+def _relation_accessor_names(model: type[Model]) -> set[str]:
+    """Names usable in ``select`` embeds: forward and reverse relations."""
+    names: set[str] = set()
+    for rel in model._meta.get_fields():
+        if rel.is_relation:
+            # ``get_accessor_name`` exists on reverse relations; forward
+            # relations expose their attribute via ``.name``.
+            accessor = getattr(rel, "get_accessor_name", None)
+            names.add(accessor() if callable(accessor) else rel.name)
+    return names
+
+
+def _is_writable_default(f: Field) -> bool:
+    if f.primary_key:
+        return False
+    if getattr(f, "auto_created", False):
+        return False
+    if getattr(f, "auto_now", False) or getattr(f, "auto_now_add", False):
+        return False
+    return f.editable
+
+
+def _default_permission_map(model: type[Model]) -> dict[str, str]:
+    meta = model._meta
+    return {
+        action: f"{meta.app_label}.{verb}_{meta.model_name}"
+        for action, verb in ACTION_TO_PERM_VERB.items()
+    }
+
+
+@dataclass
+class TableConfig:
+    """Resolved, validated configuration for a single exposed table."""
+
+    name: str
+    model: type[Model]
+    operations: tuple[str, ...]
+    fields: tuple[str, ...]
+    filterable: frozenset[str]
+    orderable: frozenset[str]
+    writable: frozenset[str]
+    embeddable: frozenset[str]
+    pk: str
+    permissions: str
+    permission_map: dict[str, str]
+    auth: Any = UNSET
+
+    def allows(self, operation: str) -> bool:
+        return operation in self.operations
+
+    @property
+    def supports_get(self) -> bool:
+        return "list" in self.operations or "read" in self.operations
+
+    def perm_codename(self, action: str) -> str:
+        return self.permission_map[action]
+
+
+def _build_table_config(name: str, raw: Any, gc: GlobalConfig) -> TableConfig:
+    # Shorthand: ``"table": "app_label.Model"``.
+    if isinstance(raw, str) or (isinstance(raw, type) and issubclass(raw, Model)):
+        raw = {"model": raw}
+    if not isinstance(raw, dict):
+        msg = f"TABLES[{name!r}] must be a dotted model path, a Model, or a dict"
+        raise TypeError(msg)
+
+    model = _resolve_model(raw["model"])
+    concrete = _concrete_field_names(model)
+    valid_tokens = _valid_field_tokens(model)
+    relations = _relation_accessor_names(model)
+
+    fields = tuple(raw.get("fields", concrete))
+    unknown = set(fields) - valid_tokens
+    if unknown:
+        msg = f"TABLES[{name!r}]['fields'] references unknown fields: {sorted(unknown)}"
+        raise ValueError(msg)
+
+    filterable = frozenset(raw.get("filterable", fields))
+    orderable = frozenset(raw.get("orderable", fields))
+
+    default_writable = [
+        f.name for f in model._meta.concrete_fields if _is_writable_default(f)
+    ]
+    writable = frozenset(raw.get("writable", default_writable))
+
+    embeddable = frozenset(raw.get("embeddable", ()))
+    bad_embeds = set(embeddable) - relations
+    if bad_embeds:
+        msg = (
+            f"TABLES[{name!r}]['embeddable'] references non-relation accessors: "
+            f"{sorted(bad_embeds)} (available: {sorted(relations)})"
+        )
+        raise ValueError(msg)
+
+    operations = tuple(raw.get("operations", ALL_OPERATIONS))
+    bad_ops = set(operations) - set(ALL_OPERATIONS)
+    if bad_ops:
+        msg = (
+            f"TABLES[{name!r}]['operations'] has unknown operations: {sorted(bad_ops)}"
+        )
+        raise ValueError(msg)
+
+    permission_map = _default_permission_map(model)
+    permission_map.update(raw.get("permission_map", {}))
+
+    permissions = raw.get("permissions", gc.default_permissions)
+
+    auth = raw["auth"] if "auth" in raw else gc.default_auth
+    if "auth" in raw:
+        auth = resolve_auth(raw["auth"])
+
+    return TableConfig(
+        name=name,
+        model=model,
+        operations=operations,
+        fields=fields,
+        filterable=filterable,
+        orderable=orderable,
+        writable=writable,
+        embeddable=embeddable,
+        pk=raw.get("pk", model._meta.pk.name),
+        permissions=permissions,
+        permission_map=permission_map,
+        auth=auth,
+    )
+
+
+_registry: dict[str, TableConfig] | None = None
+
+
+def build_registry() -> dict[str, TableConfig]:
+    gc = load_global_config()
+    return {name: _build_table_config(name, raw, gc) for name, raw in gc.tables.items()}
+
+
+def get_registry() -> dict[str, TableConfig]:
+    """Return the (cached) table registry, building it on first access."""
+    global _registry
+    if _registry is None:
+        _registry = build_registry()
+    return _registry
+
+
+def reset_registry() -> None:
+    """Clear the cached registry (used by tests overriding settings)."""
+    global _registry
+    _registry = None
+
+
+def get_table_for_model(model: type[Model]) -> TableConfig | None:
+    """Return the registered TableConfig whose model is ``model`` (or None)."""
+    for cfg in get_registry().values():
+        if cfg.model is model:
+            return cfg
+    return None
+
+
+def get_table(name: str) -> TableConfig:
+    from .exceptions import PostgrestError
+
+    try:
+        return get_registry()[name]
+    except KeyError as exc:
+        raise PostgrestError(
+            f"Unknown table {name!r}",
+            status=404,
+            code="PGRST-404",
+        ) from exc

--- a/backend/ninja_postgrest/registry.py
+++ b/backend/ninja_postgrest/registry.py
@@ -9,7 +9,7 @@ from typing import Any
 from django.apps import apps
 from django.db.models import Field, Model
 
-from .conf import UNSET, GlobalConfig, load_global_config, resolve_auth
+from .conf import UNSET, GlobalConfig, TableInputConfig, load_global_config
 
 ALL_OPERATIONS = ("list", "read", "create", "update", "delete")
 
@@ -106,35 +106,32 @@ class TableConfig:
         return self.permission_map[action]
 
 
-def _build_table_config(name: str, raw: Any, gc: GlobalConfig) -> TableConfig:
-    # Shorthand: ``"table": "app_label.Model"``.
-    if isinstance(raw, str) or (isinstance(raw, type) and issubclass(raw, Model)):
-        raw = {"model": raw}
-    if not isinstance(raw, dict):
-        msg = f"TABLES[{name!r}] must be a dotted model path, a Model, or a dict"
-        raise TypeError(msg)
-
-    model = _resolve_model(raw["model"])
+def _build_table_config(
+    name: str,
+    raw: TableInputConfig,
+    gc: GlobalConfig,
+) -> TableConfig:
+    model = _resolve_model(raw.model)
     concrete = _concrete_field_names(model)
     valid_tokens = _valid_field_tokens(model)
     relations = _relation_accessor_names(model)
 
-    fields = tuple(raw.get("fields", concrete))
+    fields = tuple(raw.fields if raw.fields is not None else concrete)
     unknown = set(fields) - valid_tokens
     if unknown:
         msg = f"TABLES[{name!r}]['fields'] references unknown fields: {sorted(unknown)}"
         raise ValueError(msg)
 
-    filterable = frozenset(raw.get("filterable", fields))
-    orderable = frozenset(raw.get("orderable", fields))
+    filterable = frozenset(raw.filterable if raw.filterable is not None else fields)
+    orderable = frozenset(raw.orderable if raw.orderable is not None else fields)
 
     default_writable = [
         f.name for f in model._meta.concrete_fields if _is_writable_default(f)
     ]
-    writable = frozenset(raw.get("writable", default_writable))
+    writable = frozenset(raw.writable if raw.writable is not None else default_writable)
 
-    embeddable = frozenset(raw.get("embeddable", ()))
-    bad_embeds = set(embeddable) - relations
+    embeddable = frozenset(raw.embeddable)
+    bad_embeds = embeddable - relations
     if bad_embeds:
         msg = (
             f"TABLES[{name!r}]['embeddable'] references non-relation accessors: "
@@ -142,22 +139,16 @@ def _build_table_config(name: str, raw: Any, gc: GlobalConfig) -> TableConfig:
         )
         raise ValueError(msg)
 
-    operations = tuple(raw.get("operations", ALL_OPERATIONS))
-    bad_ops = set(operations) - set(ALL_OPERATIONS)
-    if bad_ops:
-        msg = (
-            f"TABLES[{name!r}]['operations'] has unknown operations: {sorted(bad_ops)}"
-        )
-        raise ValueError(msg)
+    operations = tuple(raw.operations if raw.operations is not None else ALL_OPERATIONS)
 
     permission_map = _default_permission_map(model)
-    permission_map.update(raw.get("permission_map", {}))
+    permission_map.update(raw.permission_map)
 
-    permissions = raw.get("permissions", gc.default_permissions)
+    permissions = (
+        raw.permissions if raw.permissions is not None else gc.default_permissions
+    )
 
-    auth = raw["auth"] if "auth" in raw else gc.default_auth
-    if "auth" in raw:
-        auth = resolve_auth(raw["auth"])
+    auth = raw.auth if raw.auth is not UNSET else gc.default_auth
 
     return TableConfig(
         name=name,
@@ -168,7 +159,7 @@ def _build_table_config(name: str, raw: Any, gc: GlobalConfig) -> TableConfig:
         orderable=orderable,
         writable=writable,
         embeddable=embeddable,
-        pk=raw.get("pk", model._meta.pk.name),
+        pk=raw.pk if raw.pk is not None else model._meta.pk.name,
         permissions=permissions,
         permission_map=permission_map,
         auth=auth,

--- a/backend/ninja_postgrest/registry.py
+++ b/backend/ninja_postgrest/registry.py
@@ -186,6 +186,9 @@ def reset_registry() -> None:
     """Clear the cached registry (used by tests overriding settings)."""
     global _registry
     _registry = None
+    from .schemas import reset_schema_cache
+
+    reset_schema_cache()
 
 
 def get_table_for_model(model: type[Model]) -> TableConfig | None:

--- a/backend/ninja_postgrest/router.py
+++ b/backend/ninja_postgrest/router.py
@@ -1,0 +1,73 @@
+"""Build a Django-Ninja router exposing the configured tables as PostgREST
+endpoints.
+
+Routes are registered dynamically (table names come from settings) via
+``Router.add_api_operation`` rather than decorators.
+"""
+
+from __future__ import annotations
+
+from django.http import HttpRequest, JsonResponse
+from ninja import Router
+
+from .conf import UNSET
+from .registry import TableConfig, get_registry
+
+
+def _auth_kwargs(table: TableConfig) -> dict:
+    """Translate a resolved auth value into kwargs for ``add_api_operation``.
+
+    ``UNSET`` means "inherit Ninja's default" (omit the kwarg); anything else
+    (including ``None`` to disable auth) is passed through verbatim.
+    """
+    if table.auth is UNSET:
+        return {}
+    return {"auth": table.auth}
+
+
+def build_router(router: Router | None = None) -> Router:
+    """Create (or extend) a ``Router`` with operations for every configured table."""
+    router = router or Router()
+    registry = get_registry()
+
+    @router.get("/", include_in_schema=False)
+    def index(request: HttpRequest):
+        """List the table names exposed by this router."""
+        return {"tables": sorted(registry.keys())}
+
+    for table in registry.values():
+        _register_table(router, table)
+
+    return router
+
+
+def _register_table(router: Router, table: TableConfig) -> None:
+    # Per-table views are wired up in later milestones (read core / writes).
+    # Import lazily so the module graph stays acyclic and optional pieces can be
+    # added incrementally.
+    from . import views
+
+    auth = _auth_kwargs(table)
+    path = f"/{table.name}"
+
+    if table.supports_get:
+        router.add_api_operation(
+            path,
+            ["GET"],
+            views.make_list_view(table),
+            **auth,
+        )
+    if table.allows("create"):
+        router.add_api_operation(path, ["POST"], views.make_create_view(table), **auth)
+    if table.allows("update"):
+        router.add_api_operation(path, ["PATCH"], views.make_update_view(table), **auth)
+    if table.allows("delete"):
+        router.add_api_operation(
+            path,
+            ["DELETE"],
+            views.make_delete_view(table),
+            **auth,
+        )
+
+
+__all__ = ["build_router", "JsonResponse"]

--- a/backend/ninja_postgrest/router.py
+++ b/backend/ninja_postgrest/router.py
@@ -12,6 +12,7 @@ from ninja import Router
 
 from .conf import UNSET
 from .registry import TableConfig, get_registry
+from .schemas import get_full_schema
 
 
 def _auth_kwargs(table: TableConfig) -> dict:
@@ -55,6 +56,8 @@ def _register_table(router: Router, table: TableConfig) -> None:
             path,
             ["GET"],
             views.make_list_view(table),
+            response=list[get_full_schema(table)],
+            by_alias=True,
             **auth,
         )
     if table.allows("create"):

--- a/backend/ninja_postgrest/schemas.py
+++ b/backend/ninja_postgrest/schemas.py
@@ -1,0 +1,35 @@
+"""Pydantic/Ninja schema generation for documentation purposes.
+
+Responses are emitted as raw JSON (their shape depends on the dynamic
+``select``), so these schemas are used only to document the *full-row*
+representation in the OpenAPI spec. They are generated once per table and cached.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ninja.orm import create_schema
+
+from .registry import TableConfig
+
+_schema_cache: dict[str, type] = {}
+
+
+def get_full_schema(table: TableConfig) -> type:
+    """Return a cached Ninja ``Schema`` describing the table's full row."""
+    if table.name not in _schema_cache:
+        _schema_cache[table.name] = create_schema(
+            table.model,
+            name=f"Postgrest_{table.model.__name__}",
+            fields=list(table.fields),
+        )
+    return _schema_cache[table.name]
+
+
+def reset_schema_cache() -> None:
+    _schema_cache.clear()
+
+
+# A loose object type for request bodies (create/update accept arbitrary columns).
+JsonBody = dict[str, Any]

--- a/backend/ninja_postgrest/schemas.py
+++ b/backend/ninja_postgrest/schemas.py
@@ -7,8 +7,6 @@ representation in the OpenAPI spec. They are generated once per table and cached
 
 from __future__ import annotations
 
-from typing import Any
-
 from ninja.orm import create_schema
 
 from .registry import TableConfig
@@ -19,17 +17,24 @@ _schema_cache: dict[str, type] = {}
 def get_full_schema(table: TableConfig) -> type:
     """Return a cached Ninja ``Schema`` describing the table's full row."""
     if table.name not in _schema_cache:
+        # ``table.fields`` holds attnames (e.g. ``pipeline_id`` for a FK) to
+        # match PostgREST's flat columns, but ``create_schema``'s ``fields``
+        # looks fields up by Django field ``name`` (e.g. ``pipeline``), and
+        # sets the attname as the field's pydantic alias. Translating back to
+        # ``name`` here lets ``create_schema`` build the field at all; the
+        # flat column is only actually *surfaced* (including in the generated
+        # OpenAPI docs) because the GET operation is registered with
+        # ``by_alias=True`` (see router.py), which makes serialization and
+        # schema generation honor the ``pipeline_id`` alias over ``pipeline``.
+        name_by_attname = {f.attname: f.name for f in table.model._meta.concrete_fields}
+        fields = [name_by_attname.get(f, f) for f in table.fields]
         _schema_cache[table.name] = create_schema(
             table.model,
             name=f"Postgrest_{table.model.__name__}",
-            fields=list(table.fields),
+            fields=fields,
         )
     return _schema_cache[table.name]
 
 
 def reset_schema_cache() -> None:
     _schema_cache.clear()
-
-
-# A loose object type for request bodies (create/update accept arbitrary columns).
-JsonBody = dict[str, Any]

--- a/backend/ninja_postgrest/serialization.py
+++ b/backend/ninja_postgrest/serialization.py
@@ -1,0 +1,123 @@
+"""Render model instances to JSON-able dicts according to a parsed ``select``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.exceptions import FieldDoesNotExist
+from django.db.models import Model
+
+from .parsing import SelectEmbed, SelectField
+from .registry import TableConfig, get_table_for_model
+
+
+def _scalar_key_value(instance: Model, field_name: str) -> tuple[str, Any]:
+    """Return the output ``(key, value)`` for a concrete field.
+
+    Foreign keys are serialised as their scalar id column (``pipeline_id``),
+    mirroring PostgREST's flat table columns.
+    """
+    field = instance._meta.get_field(field_name)
+    if field.is_relation and (field.many_to_one or field.one_to_one):
+        return field.attname, getattr(instance, field.attname)
+    return field.name, getattr(instance, field.name)
+
+
+def _dig_json(value: Any, path: list[str]) -> Any:
+    for seg in path:
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            value = value.get(seg)
+        elif isinstance(value, list):
+            try:
+                value = value[int(seg)]
+            except (ValueError, IndexError):
+                return None
+        else:
+            return None
+    return value
+
+
+def _serialize_field(instance: Model, node: SelectField) -> tuple[str, Any]:
+    value = getattr(instance, node.column, None)
+    if node.json_path:
+        value = _dig_json(value, node.json_path)
+    else:
+        # Resolve FK scalar id when selecting the relation field by name.
+        try:
+            field = instance._meta.get_field(node.column)
+        except FieldDoesNotExist:
+            field = None
+        if (
+            field is not None
+            and field.is_relation
+            and (field.many_to_one or field.one_to_one)
+        ):
+            value = getattr(instance, field.attname)
+    return node.output_key, value
+
+
+def _default_fields(table: TableConfig | None, instance: Model) -> list[str]:
+    if table is not None:
+        return list(table.fields)
+    return [f.name for f in instance._meta.concrete_fields]
+
+
+def serialize_instance(
+    instance: Model,
+    table: TableConfig | None,
+    select: list | None,
+) -> dict[str, Any]:
+    """Serialize one instance per the ``select`` tree (or all configured fields)."""
+    out: dict[str, Any] = {}
+
+    if select is None:
+        for fname in _default_fields(table, instance):
+            key, value = _scalar_key_value(instance, fname)
+            out[key] = value
+        return out
+
+    for node in select:
+        if isinstance(node, SelectField):
+            key, value = _serialize_field(instance, node)
+            out[key] = value
+        elif isinstance(node, SelectEmbed):
+            out[node.output_key] = _serialize_embed(instance, node)
+    return out
+
+
+def _serialize_embed(instance: Model, node: SelectEmbed) -> Any:
+    related_obj = getattr(instance, node.relation, None)
+    field = _get_relation(instance, node.relation)
+    related_model = _related_model(field)
+    related_table = get_table_for_model(related_model) if related_model else None
+    child_select = node.children or None
+
+    if field is not None and (field.many_to_one or field.one_to_one):
+        # Forward FK / O2O -> single object (or null).
+        if related_obj is None:
+            return None
+        return serialize_instance(related_obj, related_table, child_select)
+
+    # Reverse FK / M2M -> manager (queryset already permission-filtered by the
+    # prefetch planner in embedding.py).
+    if related_obj is None:
+        return []
+    manager = related_obj
+    queryset = manager.all() if hasattr(manager, "all") else manager
+    return [serialize_instance(obj, related_table, child_select) for obj in queryset]
+
+
+def _get_relation(instance: Model, accessor: str):
+    for f in instance._meta.get_fields():
+        name = f.get_accessor_name() if hasattr(f, "get_accessor_name") else f.name
+        if name == accessor or getattr(f, "name", None) == accessor:
+            return f
+    return None
+
+
+def _related_model(field) -> type[Model] | None:
+    if field is None:
+        return None
+    return field.related_model

--- a/backend/ninja_postgrest/serialization.py
+++ b/backend/ninja_postgrest/serialization.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from django.core.exceptions import FieldDoesNotExist
@@ -39,10 +40,24 @@ def _dig_json(value: Any, path: list[str]) -> Any:
     return value
 
 
+def _json_text(value: Any) -> Any:
+    """Render a dug JSON value as PostgREST's ``->>`` does: text.
+
+    Strings pass through (no re-quoting), ``None`` stays ``None`` (SQL NULL),
+    and everything else (numbers, booleans, objects, arrays) becomes its JSON
+    text form.
+    """
+    if value is None or isinstance(value, str):
+        return value
+    return json.dumps(value)
+
+
 def _serialize_field(instance: Model, node: SelectField) -> tuple[str, Any]:
     value = getattr(instance, node.column, None)
     if node.json_path:
         value = _dig_json(value, node.json_path)
+        if node.json_text:
+            value = _json_text(value)
     else:
         # Resolve FK scalar id when selecting the relation field by name.
         try:

--- a/backend/ninja_postgrest/tests/conftest.py
+++ b/backend/ninja_postgrest/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Test fixtures for the ninja_postgrest suite."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_contenttype_caches():
+    """Keep guardian's and Django's ContentType caches in sync across tests.
+
+    guardian caches content types in a process-level ``lru_cache``
+    (``guardian.shortcuts._get_ct_cached``) that is never invalidated, while
+    Django clears ``ContentType.objects`` between tests. Under the ``live_server``
+    fixture those two views of the same content type can diverge and trigger a
+    spurious ``MixedContentTypeError``. Clearing both before each test keeps them
+    consistent. (Production content-type ids are stable, so this only matters in
+    tests.)
+    """
+    from django.contrib.contenttypes.models import ContentType
+    from guardian.shortcuts import _get_ct_cached
+
+    _get_ct_cached.cache_clear()
+    ContentType.objects.clear_cache()
+    yield

--- a/backend/ninja_postgrest/tests/test_conf.py
+++ b/backend/ninja_postgrest/tests/test_conf.py
@@ -1,0 +1,91 @@
+"""Tests for invalid NINJA_POSTGREST configuration.
+
+Validation happens in two layers:
+- Structural (Pydantic): caught when GlobalConfig / TableInputConfig is instantiated.
+- Model-dependent (registry): caught when _build_table_config resolves field names
+  against the actual Django model.
+"""
+
+import pytest
+from django.test import override_settings
+from pydantic import ValidationError
+
+from ninja_postgrest.conf import GlobalConfig, TableInputConfig, reset_global_config
+from ninja_postgrest.registry import build_registry, reset_registry
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    """Clear cached config/registry before and after each test."""
+    reset_global_config()
+    reset_registry()
+    yield
+    reset_global_config()
+    reset_registry()
+
+
+# --------------------------------------------------------------------------- #
+# GlobalConfig — structural validation
+# --------------------------------------------------------------------------- #
+def test_invalid_default_permissions_rejected():
+    with pytest.raises(ValidationError, match="default_permissions"):
+        GlobalConfig(default_permissions="superuser")
+
+
+def test_invalid_max_limit_rejected():
+    with pytest.raises(ValidationError, match="max_limit"):
+        GlobalConfig(max_limit="not-a-number")
+
+
+def test_invalid_table_entry_type_rejected():
+    # A bare integer is not a model path, Model class, or dict.
+    with pytest.raises(ValidationError, match="must be a dotted model path"):
+        GlobalConfig(tables={"mytable": 42})
+
+
+# --------------------------------------------------------------------------- #
+# TableInputConfig — structural validation
+# --------------------------------------------------------------------------- #
+def test_invalid_operation_rejected():
+    with pytest.raises(ValidationError, match="operations"):
+        TableInputConfig(model="datasets.Dataset", operations=["list", "patch"])
+
+
+def test_invalid_table_permissions_rejected():
+    with pytest.raises(ValidationError, match="permissions"):
+        TableInputConfig(model="datasets.Dataset", permissions="superuser")
+
+
+# --------------------------------------------------------------------------- #
+# Registry — model-dependent validation
+# --------------------------------------------------------------------------- #
+@pytest.mark.django_db
+def test_unknown_field_name_rejected():
+    overridden = {
+        "TABLES": {
+            "datasets": {
+                "model": "datasets.Dataset",
+                "fields": ["slug", "nonexistent"],
+            },
+        },
+    }
+    with override_settings(NINJA_POSTGREST=overridden):
+        reset_global_config()
+        with pytest.raises(ValueError, match="nonexistent"):
+            build_registry()
+
+
+@pytest.mark.django_db
+def test_unknown_embeddable_rejected():
+    overridden = {
+        "TABLES": {
+            "datasets": {"model": "datasets.Dataset", "embeddable": ["not_a_relation"]},
+        },
+    }
+    with override_settings(NINJA_POSTGREST=overridden):
+        reset_global_config()
+        with pytest.raises(ValueError, match="not_a_relation"):
+            build_registry()

--- a/backend/ninja_postgrest/tests/test_endpoints.py
+++ b/backend/ninja_postgrest/tests/test_endpoints.py
@@ -7,9 +7,13 @@ These run against the project's configured tables (``datasets`` /
 import json
 
 import pytest
+from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.test import Client
+from django.test import Client, override_settings
 from guardian.shortcuts import assign_perm
+
+from ninja_postgrest.conf import reset_global_config
+from ninja_postgrest.registry import reset_registry
 
 from datasets.models import Dataset, DatasetConfig
 from pipelines.models import Pipeline
@@ -181,11 +185,22 @@ def test_embed_forward_fk(datasets, admin):
 
 
 def test_embed_unregistered_model_denied(datasets, admin):
-    # 'pipeline' is listed as embeddable, but Pipeline is not a registered
-    # table -> embedding it is explicitly denied.
-    resp = client_for(admin).get(f"{PG}/datasets?select=slug,pipeline(slug)")
-    assert resp.status_code == 400
-    assert "not a registered table" in resp.json()["message"]
+    # 'pipeline' is listed as embeddable, but we simulate Pipeline not being a
+    # registered table by removing it from TABLES for this test.
+    tables_without_pipelines = {
+        k: v for k, v in settings.NINJA_POSTGREST["TABLES"].items() if k != "pipelines"
+    }
+    overridden = {**settings.NINJA_POSTGREST, "TABLES": tables_without_pipelines}
+    with override_settings(NINJA_POSTGREST=overridden):
+        reset_global_config()
+        reset_registry()
+        try:
+            resp = client_for(admin).get(f"{PG}/datasets?select=slug,pipeline(slug)")
+            assert resp.status_code == 400
+            assert "not a registered table" in resp.json()["message"]
+        finally:
+            reset_global_config()
+            reset_registry()
 
 
 def test_embed_not_allowed_400(datasets, admin):

--- a/backend/ninja_postgrest/tests/test_endpoints.py
+++ b/backend/ninja_postgrest/tests/test_endpoints.py
@@ -1,0 +1,289 @@
+"""Integration tests exercising the generated endpoints end-to-end.
+
+These run against the project's configured tables (``datasets`` /
+``dataset_configs``) so they cover the real django-ninja + guardian wiring.
+"""
+
+import json
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+from guardian.shortcuts import assign_perm
+
+from datasets.models import Dataset, DatasetConfig
+from pipelines.models import Pipeline
+
+User = get_user_model()
+PG = "/backend/api/pg"
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def pipeline():
+    return Pipeline.objects.create(
+        slug="p1",
+        name="Pipeline 1",
+        config_schema={},
+        description="",
+        active=True,
+    )
+
+
+@pytest.fixture
+def datasets(pipeline):
+    ds1 = Dataset.objects.create(slug="alpha", pipeline=pipeline)
+    ds2 = Dataset.objects.create(slug="beta", pipeline=pipeline)
+    return ds1, ds2
+
+
+@pytest.fixture
+def alice():
+    return User.objects.create_user("alice", password="pw")  # noqa: S106
+
+
+@pytest.fixture
+def admin():
+    return User.objects.create_superuser("admin", password="pw")  # noqa: S106
+
+
+def client_for(user):
+    c = Client()
+    c.force_login(user)
+    return c
+
+
+# --------------------------------------------------------------------------- #
+# Read + guardian filtering
+# --------------------------------------------------------------------------- #
+def test_list_filtered_by_guardian(datasets, alice):
+    ds1, _ds2 = datasets
+    ds1.assign_view_permission(alice)
+    resp = client_for(alice).get(f"{PG}/datasets")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert {r["slug"] for r in rows} == {"alpha"}
+
+
+def test_superuser_sees_all(datasets, admin):
+    resp = client_for(admin).get(f"{PG}/datasets")
+    assert {r["slug"] for r in resp.json()} == {"alpha", "beta"}
+
+
+def test_anonymous_unauthorized(datasets):
+    # The table inherits DEFAULT_AUTH (django_auth), so anonymous is rejected.
+    resp = Client().get(f"{PG}/datasets")
+    assert resp.status_code == 401
+
+
+def test_authenticated_without_perms_sees_nothing(datasets, alice):
+    # alice is logged in but has no object permissions on any dataset.
+    resp = client_for(alice).get(f"{PG}/datasets")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_fk_serialized_as_scalar_id(datasets, admin, pipeline):
+    rows = client_for(admin).get(f"{PG}/datasets").json()
+    assert rows[0]["pipeline_id"] == pipeline.id
+
+
+# --------------------------------------------------------------------------- #
+# Horizontal / vertical filtering, ordering, pagination
+# --------------------------------------------------------------------------- #
+def test_filter_eq(datasets, admin):
+    rows = client_for(admin).get(f"{PG}/datasets?slug=eq.beta").json()
+    assert {r["slug"] for r in rows} == {"beta"}
+
+
+def test_filter_in(datasets, admin):
+    rows = client_for(admin).get(f"{PG}/datasets?slug=in.(alpha,beta)").json()
+    assert {r["slug"] for r in rows} == {"alpha", "beta"}
+
+
+def test_select_projection(datasets, admin):
+    rows = client_for(admin).get(f"{PG}/datasets?select=slug").json()
+    assert all(set(r.keys()) == {"slug"} for r in rows)
+
+
+def test_order_desc(datasets, admin):
+    rows = client_for(admin).get(f"{PG}/datasets?select=slug&order=slug.desc").json()
+    assert [r["slug"] for r in rows] == ["beta", "alpha"]
+
+
+def test_limit(datasets, admin):
+    rows = client_for(admin).get(f"{PG}/datasets?order=slug.asc&limit=1").json()
+    assert [r["slug"] for r in rows] == ["alpha"]
+
+
+def test_content_range_header(datasets, admin):
+    resp = client_for(admin).get(f"{PG}/datasets")
+    assert resp.headers["Content-Range"] == "0-1/*"
+
+
+def test_count_exact(datasets, admin):
+    resp = client_for(admin).get(f"{PG}/datasets", headers={"Prefer": "count=exact"})
+    assert resp.headers["Content-Range"] == "0-1/2"
+
+
+# --------------------------------------------------------------------------- #
+# Singular responses
+# --------------------------------------------------------------------------- #
+SINGULAR = "application/vnd.pgrst.object+json"
+
+
+def test_single_object(datasets, admin):
+    resp = client_for(admin).get(
+        f"{PG}/datasets?slug=eq.alpha",
+        headers={"Accept": SINGULAR},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["slug"] == "alpha"
+
+
+def test_single_object_multiple_rows_406(datasets, admin):
+    resp = client_for(admin).get(f"{PG}/datasets", headers={"Accept": SINGULAR})
+    assert resp.status_code == 406
+
+
+# --------------------------------------------------------------------------- #
+# Embedding
+# --------------------------------------------------------------------------- #
+def test_embed_reverse_fk(datasets, admin):
+    ds1, _ = datasets
+    DatasetConfig.objects.create(dataset=ds1, state=DatasetConfig.State.DRAFT)
+    rows = (
+        client_for(admin)
+        .get(
+            f"{PG}/datasets?slug=eq.alpha&select=slug,configs(state)",
+            headers={"Accept": SINGULAR},
+        )
+        .json()
+    )
+    assert rows["slug"] == "alpha"
+    assert rows["configs"] == [{"state": "Draft"}]
+
+
+def test_embed_forward_fk(datasets, admin):
+    # dataset_configs -> dataset is a forward FK to a registered table.
+    ds1, _ = datasets
+    DatasetConfig.objects.create(dataset=ds1, state=DatasetConfig.State.DRAFT)
+    rows = (
+        client_for(admin)
+        .get(
+            f"{PG}/dataset_configs?select=state,dataset(slug)",
+            headers={"Accept": SINGULAR},
+        )
+        .json()
+    )
+    assert rows["dataset"] == {"slug": "alpha"}
+
+
+def test_embed_unregistered_model_denied(datasets, admin):
+    # 'pipeline' is listed as embeddable, but Pipeline is not a registered
+    # table -> embedding it is explicitly denied.
+    resp = client_for(admin).get(f"{PG}/datasets?select=slug,pipeline(slug)")
+    assert resp.status_code == 400
+    assert "not a registered table" in resp.json()["message"]
+
+
+def test_embed_not_allowed_400(datasets, admin):
+    # 'pipeline' is embeddable but a non-listed relation should 400.
+    resp = client_for(admin).get(f"{PG}/datasets?select=slug,nonsense(x)")
+    assert resp.status_code == 400
+
+
+def test_embed_reverse_fk_permission_filtered(datasets, alice):
+    """A registered embedded model (dataset_configs) is permission-filtered:
+    alice can view the parent dataset but not its configs, so the embed is empty.
+    """
+    ds1, _ = datasets
+    ds1.assign_view_permission(alice)
+    DatasetConfig.objects.create(dataset=ds1, state=DatasetConfig.State.DRAFT)
+
+    rows = (
+        client_for(alice)
+        .get(
+            f"{PG}/datasets?slug=eq.alpha&select=slug,configs(state)",
+            headers={"Accept": SINGULAR},
+        )
+        .json()
+    )
+    assert rows["slug"] == "alpha"
+    assert rows["configs"] == []  # filtered: no view_datasetconfig grant
+
+
+def test_embed_reverse_fk_visible_when_granted(datasets, alice):
+    """Granting object-level view on the embedded config makes it appear."""
+    ds1, _ = datasets
+    ds1.assign_view_permission(alice)
+    config = DatasetConfig.objects.create(dataset=ds1, state=DatasetConfig.State.DRAFT)
+    assign_perm("datasets.view_datasetconfig", alice, config)
+
+    rows = (
+        client_for(alice)
+        .get(
+            f"{PG}/datasets?slug=eq.alpha&select=slug,configs(state)",
+            headers={"Accept": SINGULAR},
+        )
+        .json()
+    )
+    assert rows["configs"] == [{"state": "Draft"}]
+
+
+# --------------------------------------------------------------------------- #
+# Writes
+# --------------------------------------------------------------------------- #
+def test_create(pipeline, admin):
+    body = {"slug": "gamma", "pipeline_id": pipeline.id, "state": "Active"}
+    resp = client_for(admin).post(
+        f"{PG}/datasets",
+        data=json.dumps(body),
+        content_type="application/json",
+        headers={"Prefer": "return=representation"},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["slug"] == "gamma"
+    assert Dataset.objects.filter(slug="gamma").exists()
+
+
+def test_update(datasets, admin):
+    resp = client_for(admin).patch(
+        f"{PG}/datasets?slug=eq.alpha",
+        data=json.dumps({"state": "Disabled"}),
+        content_type="application/json",
+        headers={"Prefer": "return=representation"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()[0]["state"] == "Disabled"
+    assert Dataset.objects.get(slug="alpha").state == "Disabled"
+
+
+def test_delete(datasets, admin):
+    resp = client_for(admin).delete(f"{PG}/datasets?slug=eq.beta")
+    assert resp.status_code == 204
+    assert not Dataset.objects.filter(slug="beta").exists()
+
+
+def test_create_rejects_non_writable_column(pipeline, admin):
+    body = {"slug": "delta", "pipeline_id": pipeline.id, "id": 999}
+    resp = client_for(admin).post(
+        f"{PG}/datasets",
+        data=json.dumps(body),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+
+# --------------------------------------------------------------------------- #
+# Errors
+# --------------------------------------------------------------------------- #
+def test_unknown_table_404(admin):
+    resp = client_for(admin).get(f"{PG}/not_a_table")
+    assert resp.status_code == 404
+
+
+def test_non_filterable_column_400(datasets, admin):
+    resp = client_for(admin).get(f"{PG}/datasets?bogus=eq.1")
+    assert resp.status_code == 400

--- a/backend/ninja_postgrest/tests/test_endpoints.py
+++ b/backend/ninja_postgrest/tests/test_endpoints.py
@@ -516,6 +516,13 @@ def test_non_filterable_column_in_or_group_400(datasets, admin):
     assert "not filterable" in resp.json()["message"]
 
 
+def test_parse_error_uses_pgrst100(datasets, admin):
+    # "slug=eq" has no operator.value form -> malformed operator parse error.
+    resp = client_for(admin).get(f"{PG}/datasets?slug=eq")
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "PGRST100"
+
+
 # --------------------------------------------------------------------------- #
 # OpenAPI documentation
 # --------------------------------------------------------------------------- #

--- a/backend/ninja_postgrest/tests/test_endpoints.py
+++ b/backend/ninja_postgrest/tests/test_endpoints.py
@@ -259,8 +259,22 @@ def test_create(pipeline, admin):
         headers={"Prefer": "return=representation"},
     )
     assert resp.status_code == 201
-    assert resp.json()["slug"] == "gamma"
+    # A single-object body still comes back as an array, matching PostgREST.
+    assert [r["slug"] for r in resp.json()] == ["gamma"]
     assert Dataset.objects.filter(slug="gamma").exists()
+
+
+def test_create_single_object_accept(pipeline, admin):
+    # The singular media type collapses the array to one object.
+    body = {"slug": "gamma", "pipeline_id": pipeline.id, "state": "Active"}
+    resp = client_for(admin).post(
+        f"{PG}/datasets",
+        data=json.dumps(body),
+        content_type="application/json",
+        headers={"Prefer": "return=representation", "Accept": SINGULAR},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["slug"] == "gamma"
 
 
 def test_update(datasets, admin):

--- a/backend/ninja_postgrest/tests/test_endpoints.py
+++ b/backend/ninja_postgrest/tests/test_endpoints.py
@@ -305,6 +305,49 @@ def test_create_rejects_non_writable_column(pipeline, admin):
     assert resp.status_code == 400
 
 
+def test_upsert_merge_duplicates_updates(datasets, admin):
+    # Upsert keyed on slug updates the existing "alpha" row instead of
+    # erroring on its unique constraint.
+    body = {"slug": "alpha", "state": "Disabled"}
+    resp = client_for(admin).post(
+        f"{PG}/datasets?on_conflict=slug",
+        data=json.dumps(body),
+        content_type="application/json",
+        headers={"Prefer": "resolution=merge-duplicates,return=representation"},
+    )
+    assert resp.status_code == 201
+    assert [r["slug"] for r in resp.json()] == ["alpha"]
+    assert Dataset.objects.filter(slug="alpha").count() == 1
+    assert Dataset.objects.get(slug="alpha").state == "Disabled"
+
+
+def test_upsert_ignore_duplicates_keeps_existing(datasets, admin):
+    body = {"slug": "alpha", "state": "Disabled"}
+    resp = client_for(admin).post(
+        f"{PG}/datasets?on_conflict=slug",
+        data=json.dumps(body),
+        content_type="application/json",
+        headers={"Prefer": "resolution=ignore-duplicates"},
+    )
+    assert resp.status_code == 201
+    # The existing row is left untouched.
+    assert Dataset.objects.filter(slug="alpha").count() == 1
+    assert Dataset.objects.get(slug="alpha").state == "Active"
+
+
+def test_upsert_without_conflict_target_inserts(pipeline, admin):
+    # No on_conflict target: an upsert degrades to a plain insert.
+    body = {"slug": "gamma", "pipeline_id": pipeline.id}
+    resp = client_for(admin).post(
+        f"{PG}/datasets",
+        data=json.dumps(body),
+        content_type="application/json",
+        headers={"Prefer": "resolution=merge-duplicates"},
+    )
+    assert resp.status_code == 201
+    assert Dataset.objects.filter(slug="gamma").exists()
+
+
 # --------------------------------------------------------------------------- #
 # Errors
 # --------------------------------------------------------------------------- #

--- a/backend/ninja_postgrest/tests/test_endpoints.py
+++ b/backend/ninja_postgrest/tests/test_endpoints.py
@@ -243,6 +243,23 @@ def test_create_single_object_accept(pipeline, admin):
     assert resp.json()["slug"] == "gamma"
 
 
+def test_create_bulk_singular_406_rolls_back(pipeline, admin):
+    # A bulk insert with the singular media type cannot return one object;
+    # the 406 must roll the whole insert back (PostgREST rolls back the request).
+    body = [
+        {"slug": "gamma", "pipeline_id": pipeline.id},
+        {"slug": "delta", "pipeline_id": pipeline.id},
+    ]
+    resp = client_for(admin).post(
+        f"{PG}/datasets",
+        data=json.dumps(body),
+        content_type="application/json",
+        headers={"Prefer": "return=representation", "Accept": SINGULAR},
+    )
+    assert resp.status_code == 406
+    assert not Dataset.objects.filter(slug__in=["gamma", "delta"]).exists()
+
+
 def test_delete(datasets, admin):
     # The client's test_client_delete always requests a representation; this
     # raw test is the only assertion of the 204 no-representation path and the
@@ -383,6 +400,33 @@ def test_columns_accepts_quoted_tokens(pipeline, admin):
     )
     assert resp.status_code == 201
     assert Dataset.objects.filter(slug="zeta").exists()
+
+
+def test_columns_applies_to_upsert(datasets, admin):
+    # ?columns= filters upsert bodies too: "state" is not listed, so the
+    # merge does not apply it and alpha's state is unchanged.
+    body = {"slug": "alpha", "state": "Disabled"}
+    resp = client_for(admin).post(
+        f"{PG}/datasets?on_conflict=slug&columns=slug",
+        data=json.dumps(body),
+        content_type="application/json",
+        headers={"Prefer": "resolution=merge-duplicates"},
+    )
+    assert resp.status_code == 201
+    assert Dataset.objects.get(slug="alpha").state == "Active"
+
+
+def test_columns_dropping_on_conflict_key_400(datasets, admin):
+    # If ?columns= drops the on_conflict key from the body, the upsert cannot
+    # key the row and reports the missing conflict column.
+    body = {"slug": "alpha", "state": "Disabled"}
+    resp = client_for(admin).post(
+        f"{PG}/datasets?on_conflict=slug&columns=state",
+        data=json.dumps(body),
+        content_type="application/json",
+        headers={"Prefer": "resolution=merge-duplicates"},
+    )
+    assert resp.status_code == 400
 
 
 def test_upsert_merge_duplicates_updates(datasets, admin):

--- a/backend/ninja_postgrest/tests/test_endpoints.py
+++ b/backend/ninja_postgrest/tests/test_endpoints.py
@@ -10,6 +10,7 @@ import pytest
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
+from django.db import connection
 from django.test import Client, override_settings
 from guardian.shortcuts import assign_perm
 
@@ -129,6 +130,24 @@ def test_explicit_limit_overrides_default_limit(datasets, admin):
         finally:
             reset_global_config()
             reset_registry()
+
+
+def test_range_header_pagination(datasets, admin):
+    resp = client_for(admin).get(
+        f"{PG}/datasets?order=slug.asc",
+        headers={"Range": "0-0"},
+    )
+    assert resp.status_code == 200
+    assert [r["slug"] for r in resp.json()] == ["alpha"]
+    assert resp.headers["Content-Range"] == "0-0/*"
+
+
+def test_select_cast_output_key(datasets, admin):
+    # ::cast is informational; the output key stays the column name.
+    rows = (
+        client_for(admin).get(f"{PG}/datasets?select=slug::text&order=slug.asc").json()
+    )
+    assert rows[0] == {"slug": "alpha"}
 
 
 # --------------------------------------------------------------------------- #
@@ -501,6 +520,20 @@ def test_parse_error_uses_pgrst100(datasets, admin):
     resp = client_for(admin).get(f"{PG}/datasets?slug=eq")
     assert resp.status_code == 400
     assert resp.json()["code"] == "PGRST100"
+
+
+# --------------------------------------------------------------------------- #
+# PG-only operators (documented skip on the SQLite test backend)
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(
+    connection.vendor != "postgresql",
+    reason="fts/plfts/phfts/wfts compile to to_tsvector @@ tsquery; PostgreSQL only",
+)
+def test_fts_requires_postgres(datasets, admin):
+    # Runs only against PostgreSQL; on the default SQLite test backend the
+    # FTS operators are covered at the Q-translation level in test_operators.
+    resp = client_for(admin).get(f"{PG}/pipelines?description=fts.pipeline")
+    assert resp.status_code == 200
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/ninja_postgrest/tests/test_endpoints.py
+++ b/backend/ninja_postgrest/tests/test_endpoints.py
@@ -127,6 +127,35 @@ def test_content_range_header(datasets, admin):
     assert resp.headers["Content-Range"] == "0-1/*"
 
 
+def test_default_limit_applied_when_unspecified(datasets, admin):
+    # With DEFAULT_LIMIT=1 and no explicit limit, only one row is returned.
+    overridden = {**settings.NINJA_POSTGREST, "DEFAULT_LIMIT": 1}
+    with override_settings(NINJA_POSTGREST=overridden):
+        reset_global_config()
+        reset_registry()
+        try:
+            resp = client_for(admin).get(f"{PG}/datasets?order=slug.asc")
+            assert resp.status_code == 200
+            assert [r["slug"] for r in resp.json()] == ["alpha"]
+            assert resp.headers["Content-Range"] == "0-0/*"
+        finally:
+            reset_global_config()
+            reset_registry()
+
+
+def test_explicit_limit_overrides_default_limit(datasets, admin):
+    overridden = {**settings.NINJA_POSTGREST, "DEFAULT_LIMIT": 1}
+    with override_settings(NINJA_POSTGREST=overridden):
+        reset_global_config()
+        reset_registry()
+        try:
+            rows = client_for(admin).get(f"{PG}/datasets?order=slug.asc&limit=2").json()
+            assert [r["slug"] for r in rows] == ["alpha", "beta"]
+        finally:
+            reset_global_config()
+            reset_registry()
+
+
 def test_count_exact(datasets, admin):
     resp = client_for(admin).get(f"{PG}/datasets", headers={"Prefer": "count=exact"})
     assert resp.headers["Content-Range"] == "0-1/2"

--- a/backend/ninja_postgrest/tests/test_endpoints.py
+++ b/backend/ninja_postgrest/tests/test_endpoints.py
@@ -302,3 +302,11 @@ def test_unknown_table_404(admin):
 def test_non_filterable_column_400(datasets, admin):
     resp = client_for(admin).get(f"{PG}/datasets?bogus=eq.1")
     assert resp.status_code == 400
+
+
+def test_non_filterable_column_in_or_group_400(datasets, admin):
+    # Logical groups must honour the same filterable allowlist as plain
+    # filters, so a non-filterable column cannot sneak in via or=(...).
+    resp = client_for(admin).get(f"{PG}/datasets?or=(bogus.eq.1,slug.eq.alpha)")
+    assert resp.status_code == 400
+    assert "not filterable" in resp.json()["message"]

--- a/backend/ninja_postgrest/tests/test_endpoints.py
+++ b/backend/ninja_postgrest/tests/test_endpoints.py
@@ -335,6 +335,57 @@ def test_create_rejects_non_writable_column(pipeline, admin):
     assert resp.status_code == 400
 
 
+def test_columns_ignores_extra_nonwritable_key(pipeline, admin):
+    # Without ?columns=, a non-writable "id" key is a 400 (see
+    # test_create_rejects_non_writable_column). With ?columns=slug,pipeline_id
+    # the extra "id" key is dropped instead of rejected.
+    body = {"slug": "delta", "pipeline_id": pipeline.id, "id": 999}
+    resp = client_for(admin).post(
+        f"{PG}/datasets?columns=slug,pipeline_id",
+        data=json.dumps(body),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    assert Dataset.objects.filter(slug="delta").exists()
+
+
+def test_columns_ignores_unlisted_values(pipeline, admin):
+    # A value sent for a column NOT in ?columns= is ignored: state falls back to
+    # its model default ("Active") rather than the "Disabled" we sent.
+    body = {"slug": "gamma", "pipeline_id": pipeline.id, "state": "Disabled"}
+    resp = client_for(admin).post(
+        f"{PG}/datasets?columns=slug,pipeline_id",
+        data=json.dumps(body),
+        content_type="application/json",
+        headers={"Prefer": "return=representation"},
+    )
+    assert resp.status_code == 201
+    assert Dataset.objects.get(slug="gamma").state == "Active"
+
+
+def test_columns_unknown_column_400(pipeline, admin):
+    body = {"slug": "gamma", "pipeline_id": pipeline.id}
+    resp = client_for(admin).post(
+        f"{PG}/datasets?columns=bogus",
+        data=json.dumps(body),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+
+def test_columns_accepts_quoted_tokens(pipeline, admin):
+    # Real PostgREST clients send quoted identifiers, e.g. columns="slug","pipeline_id".
+    # The quoted form must behave identically to the unquoted form (extra "id" dropped).
+    body = {"slug": "zeta", "pipeline_id": pipeline.id, "id": 999}
+    resp = client_for(admin).post(
+        f'{PG}/datasets?columns="slug","pipeline_id"',
+        data=json.dumps(body),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    assert Dataset.objects.filter(slug="zeta").exists()
+
+
 def test_upsert_merge_duplicates_updates(datasets, admin):
     # Upsert keyed on slug updates the existing "alpha" row instead of
     # erroring on its unique constraint.

--- a/backend/ninja_postgrest/tests/test_endpoints.py
+++ b/backend/ninja_postgrest/tests/test_endpoints.py
@@ -463,3 +463,25 @@ def test_non_filterable_column_in_or_group_400(datasets, admin):
     resp = client_for(admin).get(f"{PG}/datasets?or=(bogus.eq.1,slug.eq.alpha)")
     assert resp.status_code == 400
     assert "not filterable" in resp.json()["message"]
+
+
+# --------------------------------------------------------------------------- #
+# OpenAPI documentation
+# --------------------------------------------------------------------------- #
+def test_openapi_documents_full_row_read_schema():
+    from ninja import NinjaAPI
+
+    from ninja_postgrest import build_router
+
+    api = NinjaAPI()
+    api.add_router("/pg/", build_router())
+    schema = api.get_openapi_schema()
+    # get_full_schema names the component "Postgrest_<Model>"; it appears in
+    # components only because the GET operation references it via response=.
+    assert "Postgrest_Dataset" in schema["components"]["schemas"]
+    # The GET operation is registered with by_alias=True, so the component
+    # must document the flat PostgREST scalar column (the FK attname), not
+    # the nested Django relation name.
+    props = schema["components"]["schemas"]["Postgrest_Dataset"]["properties"]
+    assert "pipeline_id" in props  # flat PostgREST scalar column
+    assert "pipeline" not in props  # not the nested relation name

--- a/backend/ninja_postgrest/tests/test_endpoints.py
+++ b/backend/ninja_postgrest/tests/test_endpoints.py
@@ -325,6 +325,78 @@ def test_delete(datasets, admin):
     assert not Dataset.objects.filter(slug="beta").exists()
 
 
+def test_create_sets_location_header(pipeline, admin):
+    body = {"slug": "gamma", "pipeline_id": pipeline.id}
+    resp = client_for(admin).post(
+        f"{PG}/datasets",
+        data=json.dumps(body),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    obj = Dataset.objects.get(slug="gamma")
+    assert resp.headers["Location"] == f"{PG}/datasets?id=eq.{obj.id}"
+
+
+def test_create_bulk_location_uses_in_filter(pipeline, admin):
+    body = [
+        {"slug": "gamma", "pipeline_id": pipeline.id},
+        {"slug": "delta", "pipeline_id": pipeline.id},
+    ]
+    resp = client_for(admin).post(
+        f"{PG}/datasets",
+        data=json.dumps(body),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    g = Dataset.objects.get(slug="gamma").id
+    d = Dataset.objects.get(slug="delta").id
+    assert resp.headers["Location"] == f"{PG}/datasets?id=in.({g},{d})"
+
+
+def test_patch_single_object_accept(datasets, admin):
+    resp = client_for(admin).patch(
+        f"{PG}/datasets?slug=eq.alpha",
+        data=json.dumps({"state": "Disabled"}),
+        content_type="application/json",
+        headers={"Prefer": "return=representation", "Accept": SINGULAR},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["slug"] == "alpha"  # a single object, not an array
+
+
+def test_patch_singular_multiple_rows_406_rolls_back(datasets, admin):
+    # No filter matches both alpha and beta; singular + representation -> 406,
+    # and the update must roll back (both rows unchanged).
+    resp = client_for(admin).patch(
+        f"{PG}/datasets",
+        data=json.dumps({"state": "Disabled"}),
+        content_type="application/json",
+        headers={"Prefer": "return=representation", "Accept": SINGULAR},
+    )
+    assert resp.status_code == 406
+    assert Dataset.objects.get(slug="alpha").state == "Active"
+    assert Dataset.objects.get(slug="beta").state == "Active"
+
+
+def test_delete_single_object_accept(datasets, admin):
+    resp = client_for(admin).delete(
+        f"{PG}/datasets?slug=eq.beta",
+        headers={"Prefer": "return=representation", "Accept": SINGULAR},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["slug"] == "beta"  # a single object, not an array
+    assert not Dataset.objects.filter(slug="beta").exists()
+
+
+def test_delete_singular_multiple_rows_406_no_delete(datasets, admin):
+    resp = client_for(admin).delete(
+        f"{PG}/datasets",
+        headers={"Prefer": "return=representation", "Accept": SINGULAR},
+    )
+    assert resp.status_code == 406
+    assert Dataset.objects.count() == 2  # nothing deleted
+
+
 def test_create_rejects_non_writable_column(pipeline, admin):
     body = {"slug": "delta", "pipeline_id": pipeline.id, "id": 999}
     resp = client_for(admin).post(

--- a/backend/ninja_postgrest/tests/test_endpoints.py
+++ b/backend/ninja_postgrest/tests/test_endpoints.py
@@ -1,7 +1,7 @@
-"""Integration tests exercising the generated endpoints end-to-end.
-
-These run against the project's configured tables (``datasets`` /
-``dataset_configs``) so they cover the real django-ninja + guardian wiring.
+"""Integration tests for the raw HTTP surface: auth/permissions, status codes
+and headers, settings overrides, and behaviors the ``postgrest`` client
+library cannot express. The plain CRUD/filter matrix lives in
+``test_postgrest_client.py``.
 """
 
 import json
@@ -97,31 +97,6 @@ def test_fk_serialized_as_scalar_id(datasets, admin, pipeline):
 # --------------------------------------------------------------------------- #
 # Horizontal / vertical filtering, ordering, pagination
 # --------------------------------------------------------------------------- #
-def test_filter_eq(datasets, admin):
-    rows = client_for(admin).get(f"{PG}/datasets?slug=eq.beta").json()
-    assert {r["slug"] for r in rows} == {"beta"}
-
-
-def test_filter_in(datasets, admin):
-    rows = client_for(admin).get(f"{PG}/datasets?slug=in.(alpha,beta)").json()
-    assert {r["slug"] for r in rows} == {"alpha", "beta"}
-
-
-def test_select_projection(datasets, admin):
-    rows = client_for(admin).get(f"{PG}/datasets?select=slug").json()
-    assert all(set(r.keys()) == {"slug"} for r in rows)
-
-
-def test_order_desc(datasets, admin):
-    rows = client_for(admin).get(f"{PG}/datasets?select=slug&order=slug.desc").json()
-    assert [r["slug"] for r in rows] == ["beta", "alpha"]
-
-
-def test_limit(datasets, admin):
-    rows = client_for(admin).get(f"{PG}/datasets?order=slug.asc&limit=1").json()
-    assert [r["slug"] for r in rows] == ["alpha"]
-
-
 def test_content_range_header(datasets, admin):
     resp = client_for(admin).get(f"{PG}/datasets")
     assert resp.headers["Content-Range"] == "0-1/*"
@@ -156,24 +131,10 @@ def test_explicit_limit_overrides_default_limit(datasets, admin):
             reset_registry()
 
 
-def test_count_exact(datasets, admin):
-    resp = client_for(admin).get(f"{PG}/datasets", headers={"Prefer": "count=exact"})
-    assert resp.headers["Content-Range"] == "0-1/2"
-
-
 # --------------------------------------------------------------------------- #
 # Singular responses
 # --------------------------------------------------------------------------- #
 SINGULAR = "application/vnd.pgrst.object+json"
-
-
-def test_single_object(datasets, admin):
-    resp = client_for(admin).get(
-        f"{PG}/datasets?slug=eq.alpha",
-        headers={"Accept": SINGULAR},
-    )
-    assert resp.status_code == 200
-    assert resp.json()["slug"] == "alpha"
 
 
 def test_single_object_multiple_rows_406(datasets, admin):
@@ -184,36 +145,6 @@ def test_single_object_multiple_rows_406(datasets, admin):
 # --------------------------------------------------------------------------- #
 # Embedding
 # --------------------------------------------------------------------------- #
-def test_embed_reverse_fk(datasets, admin):
-    ds1, _ = datasets
-    DatasetConfig.objects.create(dataset=ds1, state=DatasetConfig.State.DRAFT)
-    rows = (
-        client_for(admin)
-        .get(
-            f"{PG}/datasets?slug=eq.alpha&select=slug,configs(state)",
-            headers={"Accept": SINGULAR},
-        )
-        .json()
-    )
-    assert rows["slug"] == "alpha"
-    assert rows["configs"] == [{"state": "Draft"}]
-
-
-def test_embed_forward_fk(datasets, admin):
-    # dataset_configs -> dataset is a forward FK to a registered table.
-    ds1, _ = datasets
-    DatasetConfig.objects.create(dataset=ds1, state=DatasetConfig.State.DRAFT)
-    rows = (
-        client_for(admin)
-        .get(
-            f"{PG}/dataset_configs?select=state,dataset(slug)",
-            headers={"Accept": SINGULAR},
-        )
-        .json()
-    )
-    assert rows["dataset"] == {"slug": "alpha"}
-
-
 def test_embed_unregistered_model_denied(datasets, admin):
     # 'pipeline' is listed as embeddable, but we simulate Pipeline not being a
     # registered table by removing it from TABLES for this test.
@@ -280,20 +211,6 @@ def test_embed_reverse_fk_visible_when_granted(datasets, alice):
 # --------------------------------------------------------------------------- #
 # Writes
 # --------------------------------------------------------------------------- #
-def test_create(pipeline, admin):
-    body = {"slug": "gamma", "pipeline_id": pipeline.id, "state": "Active"}
-    resp = client_for(admin).post(
-        f"{PG}/datasets",
-        data=json.dumps(body),
-        content_type="application/json",
-        headers={"Prefer": "return=representation"},
-    )
-    assert resp.status_code == 201
-    # A single-object body still comes back as an array, matching PostgREST.
-    assert [r["slug"] for r in resp.json()] == ["gamma"]
-    assert Dataset.objects.filter(slug="gamma").exists()
-
-
 def test_create_single_object_accept(pipeline, admin):
     # The singular media type collapses the array to one object.
     body = {"slug": "gamma", "pipeline_id": pipeline.id, "state": "Active"}
@@ -307,19 +224,10 @@ def test_create_single_object_accept(pipeline, admin):
     assert resp.json()["slug"] == "gamma"
 
 
-def test_update(datasets, admin):
-    resp = client_for(admin).patch(
-        f"{PG}/datasets?slug=eq.alpha",
-        data=json.dumps({"state": "Disabled"}),
-        content_type="application/json",
-        headers={"Prefer": "return=representation"},
-    )
-    assert resp.status_code == 200
-    assert resp.json()[0]["state"] == "Disabled"
-    assert Dataset.objects.get(slug="alpha").state == "Disabled"
-
-
 def test_delete(datasets, admin):
+    # The client's test_client_delete always requests a representation; this
+    # raw test is the only assertion of the 204 no-representation path and the
+    # literal status code (the client hides status codes).
     resp = client_for(admin).delete(f"{PG}/datasets?slug=eq.beta")
     assert resp.status_code == 204
     assert not Dataset.objects.filter(slug="beta").exists()

--- a/backend/ninja_postgrest/tests/test_endpoints.py
+++ b/backend/ninja_postgrest/tests/test_endpoints.py
@@ -399,6 +399,23 @@ def test_upsert_merge_inserts_new_row_with_add_perm(pipeline, alice):
 
 
 # --------------------------------------------------------------------------- #
+# Write authorization
+# --------------------------------------------------------------------------- #
+# Guardian filtering of PATCH/DELETE for non-superusers is covered end-to-end
+# through the real client in test_postgrest_client.py. Here we only assert the
+# auth layer applies to writes, which the (always-authenticated) client cannot.
+def test_anonymous_write_unauthorized(datasets):
+    # Writes inherit DEFAULT_AUTH, so an unauthenticated PATCH is rejected.
+    resp = Client().patch(
+        f"{PG}/datasets?slug=eq.alpha",
+        data=json.dumps({"state": "Disabled"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 401
+    assert Dataset.objects.get(slug="alpha").state == "Active"
+
+
+# --------------------------------------------------------------------------- #
 # Errors
 # --------------------------------------------------------------------------- #
 def test_unknown_table_404(admin):

--- a/backend/ninja_postgrest/tests/test_endpoints.py
+++ b/backend/ninja_postgrest/tests/test_endpoints.py
@@ -9,6 +9,7 @@ import json
 import pytest
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.test import Client, override_settings
 from guardian.shortcuts import assign_perm
 
@@ -340,6 +341,55 @@ def test_upsert_without_conflict_target_inserts(pipeline, admin):
     body = {"slug": "gamma", "pipeline_id": pipeline.id}
     resp = client_for(admin).post(
         f"{PG}/datasets",
+        data=json.dumps(body),
+        content_type="application/json",
+        headers={"Prefer": "resolution=merge-duplicates"},
+    )
+    assert resp.status_code == 201
+    assert Dataset.objects.filter(slug="gamma").exists()
+
+
+def _grant_add_dataset(user):
+    user.user_permissions.add(Permission.objects.get(codename="add_dataset"))
+
+
+def test_upsert_merge_denied_without_change_perm(datasets, alice):
+    # alice may create datasets (model-level add) but has no change permission
+    # on the existing "alpha", so a merge that would update it is forbidden.
+    _grant_add_dataset(alice)
+    body = {"slug": "alpha", "state": "Disabled"}
+    resp = client_for(alice).post(
+        f"{PG}/datasets?on_conflict=slug",
+        data=json.dumps(body),
+        content_type="application/json",
+        headers={"Prefer": "resolution=merge-duplicates"},
+    )
+    assert resp.status_code == 403
+    assert Dataset.objects.get(slug="alpha").state == "Active"  # unchanged
+
+
+def test_upsert_merge_allowed_with_change_perm(datasets, alice):
+    # Granting object-level change on "alpha" lets the merge update it.
+    ds1, _ = datasets
+    _grant_add_dataset(alice)
+    ds1.assign_edit_permission(alice)  # view + change on alpha
+    body = {"slug": "alpha", "state": "Disabled"}
+    resp = client_for(alice).post(
+        f"{PG}/datasets?on_conflict=slug",
+        data=json.dumps(body),
+        content_type="application/json",
+        headers={"Prefer": "resolution=merge-duplicates"},
+    )
+    assert resp.status_code == 201
+    assert Dataset.objects.get(slug="alpha").state == "Disabled"
+
+
+def test_upsert_merge_inserts_new_row_with_add_perm(pipeline, alice):
+    # A brand-new row is an insert, so the model-level add perm alone suffices.
+    _grant_add_dataset(alice)
+    body = {"slug": "gamma", "pipeline_id": pipeline.id}
+    resp = client_for(alice).post(
+        f"{PG}/datasets?on_conflict=slug",
         data=json.dumps(body),
         content_type="application/json",
         headers={"Prefer": "resolution=merge-duplicates"},

--- a/backend/ninja_postgrest/tests/test_endpoints.py
+++ b/backend/ninja_postgrest/tests/test_endpoints.py
@@ -150,6 +150,24 @@ def test_select_cast_output_key(datasets, admin):
     assert rows[0] == {"slug": "alpha"}
 
 
+def test_json_path_text_extraction_edges(datasets, admin):
+    # ->> renders booleans as JSON text; null and missing keys stay null.
+    ds1, _ = datasets
+    DatasetConfig.objects.create(
+        dataset=ds1,
+        state=DatasetConfig.State.DRAFT,
+        config={"flag": True, "empty": None},
+    )
+    rows = (
+        client_for(admin)
+        .get(
+            f"{PG}/dataset_configs?select=flag:config->>flag,empty:config->>empty,nope:config->>nope",
+        )
+        .json()
+    )
+    assert rows == [{"flag": "true", "empty": None, "nope": None}]
+
+
 # --------------------------------------------------------------------------- #
 # Singular responses
 # --------------------------------------------------------------------------- #

--- a/backend/ninja_postgrest/tests/test_operators.py
+++ b/backend/ninja_postgrest/tests/test_operators.py
@@ -1,0 +1,38 @@
+"""Unit tests for PostgREST operator -> Django ``Q`` translation."""
+
+from django.db.models import Q
+
+from ninja_postgrest.operators import build_q
+
+
+def test_eq():
+    assert build_q("age", "eq.18") == Q(age__exact="18")
+
+
+def test_comparisons():
+    assert build_q("age", "gte.18") == Q(age__gte="18")
+    assert build_q("age", "lt.5") == Q(age__lt="5")
+
+
+def test_neq_is_negated():
+    assert build_q("name", "neq.bob") == ~Q(name__exact="bob")
+
+
+def test_not_prefix_negates():
+    assert build_q("age", "not.gte.18") == ~Q(age__gte="18")
+
+
+def test_like_translates_star_to_percent():
+    assert build_q("name", "like.J*") == Q(name__like="J%")
+
+
+def test_in_parses_list():
+    assert build_q("id", "in.(1,2,3)") == Q(id__in=["1", "2", "3"])
+
+
+def test_is_null():
+    assert build_q("deleted", "is.null") == Q(deleted__isnull=True)
+
+
+def test_is_true():
+    assert build_q("active", "is.true") == Q(active__exact=True)

--- a/backend/ninja_postgrest/tests/test_operators.py
+++ b/backend/ninja_postgrest/tests/test_operators.py
@@ -41,3 +41,45 @@ def test_is_true():
 def test_isdistinct_is_null_safe():
     # IS DISTINCT FROM must return NULL rows too, unlike a bare ~exact.
     assert build_q("age", "isdistinct.5") == (~Q(age__exact="5") | Q(age__isnull=True))
+
+
+def test_match_and_imatch_are_regex():
+    assert build_q("slug", "match.^al") == Q(slug__regex="^al")
+    assert build_q("slug", "imatch.^AL") == Q(slug__iregex="^AL")
+
+
+def test_set_operators_parse_lists():
+    # PG array/range operators translate to the PG-specific lookups; SQLite
+    # cannot execute them, so coverage is at the Q-translation level.
+    assert build_q("tags", "cs.{a,b}") == Q(tags__contains=["a", "b"])
+    assert build_q("tags", "cd.{a,b}") == Q(tags__contained_by=["a", "b"])
+    assert build_q("tags", "ov.{a,b}") == Q(tags__overlap=["a", "b"])
+
+
+def test_fts_operators_build_search_queries():
+    from django.contrib.postgres.search import SearchQuery
+
+    assert build_q("description", "fts.cat") == Q(
+        description__search=SearchQuery("cat", config=None, search_type="plain"),
+    )
+    assert build_q("description", "plfts.cat") == Q(
+        description__search=SearchQuery("cat", config=None, search_type="plain"),
+    )
+    assert build_q("description", "phfts.fat cat") == Q(
+        description__search=SearchQuery("fat cat", config=None, search_type="phrase"),
+    )
+    assert build_q("description", "wfts.fat or cat") == Q(
+        description__search=SearchQuery(
+            "fat or cat",
+            config=None,
+            search_type="websearch",
+        ),
+    )
+
+
+def test_fts_config_modifier():
+    from django.contrib.postgres.search import SearchQuery
+
+    assert build_q("description", "fts(english).cat") == Q(
+        description__search=SearchQuery("cat", config="english", search_type="plain"),
+    )

--- a/backend/ninja_postgrest/tests/test_operators.py
+++ b/backend/ninja_postgrest/tests/test_operators.py
@@ -36,3 +36,8 @@ def test_is_null():
 
 def test_is_true():
     assert build_q("active", "is.true") == Q(active__exact=True)
+
+
+def test_isdistinct_is_null_safe():
+    # IS DISTINCT FROM must return NULL rows too, unlike a bare ~exact.
+    assert build_q("age", "isdistinct.5") == (~Q(age__exact="5") | Q(age__isnull=True))

--- a/backend/ninja_postgrest/tests/test_parsing.py
+++ b/backend/ninja_postgrest/tests/test_parsing.py
@@ -1,0 +1,64 @@
+"""Unit tests for the query-string parser."""
+
+from django.db.models import Q
+
+from ninja_postgrest.parsing import (
+    SelectEmbed,
+    SelectField,
+    _parse_logical,
+    parse_order,
+    parse_select,
+    split_top_level,
+)
+
+
+def test_split_top_level_respects_parens():
+    assert split_top_level("a,b(c,d),e") == ["a", "b(c,d)", "e"]
+
+
+def test_parse_select_fields_and_embed():
+    nodes = parse_select("slug,configs(state,created),pipeline_id")
+    assert isinstance(nodes[0], SelectField)
+    assert nodes[0].column == "slug"
+    assert isinstance(nodes[1], SelectEmbed)
+    assert nodes[1].relation == "configs"
+    assert [c.column for c in nodes[1].children] == ["state", "created"]
+    assert isinstance(nodes[2], SelectField)
+    assert nodes[2].column == "pipeline_id"
+
+
+def test_parse_select_alias_and_cast():
+    (node,) = parse_select("name:slug")
+    assert node.alias == "name"
+    assert node.column == "slug"
+    assert node.output_key == "name"
+
+    (cast_node,) = parse_select("count::text")
+    assert cast_node.column == "count"
+    assert cast_node.cast == "text"
+
+
+def test_parse_select_json_path():
+    (node,) = parse_select("config->>units")
+    assert node.column == "config"
+    assert node.json_path == ["units"]
+    assert node.json_text is True
+
+
+def test_parse_order():
+    terms = parse_order("created.desc.nullslast,slug")
+    assert terms[0].column == "created"
+    assert terms[0].descending is True
+    assert terms[0].nulls == "last"
+    assert terms[1].column == "slug"
+    assert terms[1].descending is False
+
+
+def test_logical_or():
+    q = _parse_logical("(slug.eq.a,slug.eq.b)", "or")
+    assert q == (Q(slug__exact="a") | Q(slug__exact="b"))
+
+
+def test_logical_and():
+    q = _parse_logical("(state.eq.Active,slug.eq.a)", "and")
+    assert q == (Q(state__exact="Active") & Q(slug__exact="a"))

--- a/backend/ninja_postgrest/tests/test_postgrest_client.py
+++ b/backend/ninja_postgrest/tests/test_postgrest_client.py
@@ -1,0 +1,118 @@
+"""Validate the generated endpoints against the standard ``postgrest`` client
+library (https://pypi.org/project/postgrest/).
+
+These exercise the real HTTP surface end-to-end: a live server, django-ninja
+auth (via a session cookie), guardian filtering and the PostgREST query grammar
+as produced by a third-party client rather than hand-built URLs.
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+
+postgrest = pytest.importorskip("postgrest")
+from postgrest import SyncPostgrestClient  # noqa: E402
+
+from datasets.models import Dataset, DatasetConfig  # noqa: E402
+from pipelines.models import Pipeline  # noqa: E402
+
+User = get_user_model()
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def seeded():
+    pipeline = Pipeline.objects.create(
+        slug="p1",
+        name="Pipeline 1",
+        config_schema={},
+        description="",
+        active=True,
+    )
+    ds1 = Dataset.objects.create(slug="alpha", pipeline=pipeline)
+    Dataset.objects.create(slug="beta", pipeline=pipeline)
+    DatasetConfig.objects.create(dataset=ds1, state=DatasetConfig.State.DRAFT)
+    return pipeline
+
+
+@pytest.fixture
+def admin():
+    return User.objects.create_superuser("admin", password="pw")  # noqa: S106
+
+
+def pg_client(live_server, user) -> SyncPostgrestClient:
+    """A PostgREST client authenticated as ``user`` via a Django session cookie."""
+    django_client = Client()
+    django_client.force_login(user)
+    sessionid = django_client.cookies["sessionid"].value
+    # base_url must end with "/" so httpx preserves the /backend/api/pg prefix
+    # when it appends the table path.
+    return SyncPostgrestClient(
+        f"{live_server.url}/backend/api/pg/",
+        headers={"Cookie": f"sessionid={sessionid}"},
+    )
+
+
+def test_client_select_and_order(live_server, seeded, admin):
+    pg = pg_client(live_server, admin)
+    res = pg.from_("datasets").select("slug").order("slug").execute()
+    assert [r["slug"] for r in res.data] == ["alpha", "beta"]
+
+
+def test_client_filter_eq(live_server, seeded, admin):
+    pg = pg_client(live_server, admin)
+    res = pg.from_("datasets").select("slug").eq("slug", "beta").execute()
+    assert [r["slug"] for r in res.data] == ["beta"]
+
+
+def test_client_filter_in(live_server, seeded, admin):
+    pg = pg_client(live_server, admin)
+    res = pg.from_("datasets").select("slug").in_("slug", ["alpha", "beta"]).execute()
+    assert {r["slug"] for r in res.data} == {"alpha", "beta"}
+
+
+def test_client_limit(live_server, seeded, admin):
+    pg = pg_client(live_server, admin)
+    res = pg.from_("datasets").select("slug").order("slug").limit(1).execute()
+    assert [r["slug"] for r in res.data] == ["alpha"]
+
+
+def test_client_single(live_server, seeded, admin):
+    pg = pg_client(live_server, admin)
+    res = pg.from_("datasets").select("slug").eq("slug", "alpha").single().execute()
+    assert res.data["slug"] == "alpha"
+
+
+def test_client_count_exact(live_server, seeded, admin):
+    pg = pg_client(live_server, admin)
+    res = pg.from_("datasets").select("slug", count="exact").execute()
+    assert res.count == 2
+
+
+def test_client_embed_reverse_fk(live_server, seeded, admin):
+    pg = pg_client(live_server, admin)
+    res = (
+        pg.from_("datasets")
+        .select("slug,configs(state)")
+        .eq("slug", "alpha")
+        .single()
+        .execute()
+    )
+    assert res.data["slug"] == "alpha"
+    assert res.data["configs"] == [{"state": "Draft"}]
+
+
+def test_client_embed_forward_fk(live_server, seeded, admin):
+    # dataset_configs -> dataset is a forward FK to a registered table.
+    pg = pg_client(live_server, admin)
+    res = pg.from_("dataset_configs").select("state,dataset(slug)").single().execute()
+    assert res.data["dataset"] == {"slug": "alpha"}
+
+
+def test_client_guardian_filtering(live_server, seeded):
+    """A user with no object permissions sees no rows through the client."""
+    bob = User.objects.create_user("bob", password="pw")  # noqa: S106
+    pg = pg_client(live_server, bob)
+    res = pg.from_("datasets").select("slug").execute()
+    assert res.data == []

--- a/backend/ninja_postgrest/tests/test_postgrest_client.py
+++ b/backend/ninja_postgrest/tests/test_postgrest_client.py
@@ -12,6 +12,7 @@ from django.test import Client
 
 postgrest = pytest.importorskip("postgrest")
 from postgrest import SyncPostgrestClient  # noqa: E402
+from postgrest.exceptions import APIError  # noqa: E402
 
 from datasets.models import Dataset, DatasetConfig  # noqa: E402
 from pipelines.models import Pipeline  # noqa: E402
@@ -116,3 +117,130 @@ def test_client_guardian_filtering(live_server, seeded):
     pg = pg_client(live_server, bob)
     res = pg.from_("datasets").select("slug").execute()
     assert res.data == []
+
+
+# --------------------------------------------------------------------------- #
+# Writes through the real client (insert / update / delete / upsert)
+# --------------------------------------------------------------------------- #
+def test_client_insert_single(live_server, seeded, admin):
+    pipeline = seeded
+    pg = pg_client(live_server, admin)
+    pg.from_("datasets").insert(
+        {"slug": "gamma", "pipeline_id": pipeline.id, "state": "Active"},
+    ).execute()
+    # Verify the round-trip by reading the new row back through the client.
+    res = (
+        pg.from_("datasets").select("slug,state").eq("slug", "gamma").single().execute()
+    )
+    assert res.data == {"slug": "gamma", "state": "Active"}
+    assert Dataset.objects.filter(slug="gamma").exists()
+
+
+def test_client_insert_bulk(live_server, seeded, admin):
+    pipeline = seeded
+    pg = pg_client(live_server, admin)
+    res = (
+        pg.from_("datasets")
+        .insert(
+            [
+                {"slug": "gamma", "pipeline_id": pipeline.id},
+                {"slug": "delta", "pipeline_id": pipeline.id},
+            ],
+        )
+        .execute()
+    )
+    assert {r["slug"] for r in res.data} == {"gamma", "delta"}
+    assert Dataset.objects.filter(slug__in=["gamma", "delta"]).count() == 2
+
+
+def test_client_update(live_server, seeded, admin):
+    pg = pg_client(live_server, admin)
+    res = (
+        pg.from_("datasets").update({"state": "Disabled"}).eq("slug", "alpha").execute()
+    )
+    assert [r["state"] for r in res.data] == ["Disabled"]
+    assert Dataset.objects.get(slug="alpha").state == "Disabled"
+
+
+def test_client_delete(live_server, seeded, admin):
+    pg = pg_client(live_server, admin)
+    res = pg.from_("datasets").delete().eq("slug", "beta").execute()
+    assert [r["slug"] for r in res.data] == ["beta"]
+    assert not Dataset.objects.filter(slug="beta").exists()
+    assert Dataset.objects.filter(slug="alpha").exists()
+
+
+def test_client_upsert_new_row(live_server, seeded, admin):
+    # Upsert of a *new* row behaves like an insert; the server ignores the
+    # ``Prefer: resolution`` header. Conflict-resolution (updating an existing
+    # row on a unique-key clash) is not implemented server-side, so this only
+    # exercises the no-conflict path.
+    pipeline = seeded
+    pg = pg_client(live_server, admin)
+    pg.from_("datasets").upsert(
+        {"slug": "epsilon", "pipeline_id": pipeline.id},
+    ).execute()
+    assert Dataset.objects.filter(slug="epsilon").exists()
+
+
+# --------------------------------------------------------------------------- #
+# Filter grammar as emitted by the client
+# --------------------------------------------------------------------------- #
+def test_client_like(live_server, seeded, admin):
+    pg = pg_client(live_server, admin)
+    res = pg.from_("datasets").select("slug").like("slug", "al*").execute()
+    assert [r["slug"] for r in res.data] == ["alpha"]
+
+
+def test_client_ilike_case_insensitive(live_server, seeded, admin):
+    # An upper-case pattern still matches the lower-case slug.
+    pg = pg_client(live_server, admin)
+    res = pg.from_("datasets").select("slug").ilike("slug", "*LPH*").execute()
+    assert [r["slug"] for r in res.data] == ["alpha"]
+
+
+def test_client_range_comparison(live_server, seeded, admin):
+    pg = pg_client(live_server, admin)
+    res = pg.from_("datasets").select("slug").gte("slug", "b").order("slug").execute()
+    assert [r["slug"] for r in res.data] == ["beta"]
+
+
+def test_client_or_filter(live_server, seeded, admin):
+    pg = pg_client(live_server, admin)
+    res = (
+        pg.from_("datasets")
+        .select("slug")
+        .or_("slug.eq.alpha,slug.eq.beta")
+        .order("slug")
+        .execute()
+    )
+    assert [r["slug"] for r in res.data] == ["alpha", "beta"]
+
+
+def test_client_is_null(live_server, seeded, admin):
+    # No dataset has a null state, so is.null returns nothing — this exercises
+    # the ``is`` operator round-tripping through the client and the endpoint.
+    pg = pg_client(live_server, admin)
+    res = pg.from_("datasets").select("slug").is_("state", "null").execute()
+    assert res.data == []
+
+
+# --------------------------------------------------------------------------- #
+# Error contract: PostgREST JSON error shape as parsed by the client
+# --------------------------------------------------------------------------- #
+def test_client_single_multiple_rows_raises_apierror(live_server, seeded, admin):
+    pg = pg_client(live_server, admin)
+    with pytest.raises(APIError) as excinfo:
+        pg.from_("datasets").select("slug").single().execute()
+    err = excinfo.value
+    assert err.code == "PGRST-406"
+    assert "exactly one row" in err.message
+
+
+def test_client_non_filterable_column_raises_apierror(live_server, seeded, admin):
+    pg = pg_client(live_server, admin)
+    with pytest.raises(APIError) as excinfo:
+        pg.from_("datasets").select("slug").eq("bogus", "1").execute()
+    err = excinfo.value
+    assert err.code == "PGRST-400"
+    assert "not filterable" in err.message

--- a/backend/ninja_postgrest/tests/test_postgrest_client.py
+++ b/backend/ninja_postgrest/tests/test_postgrest_client.py
@@ -66,6 +66,11 @@ def test_client_select_and_order(live_server, seeded, admin):
     pg = pg_client(live_server, admin)
     res = pg.from_("datasets").select("slug").order("slug").execute()
     assert [r["slug"] for r in res.data] == ["alpha", "beta"]
+    # The projection is exact: no other columns leak into the rows.
+    assert all(set(r.keys()) == {"slug"} for r in res.data)
+    # Descending through the client's order grammar (order=slug.desc).
+    res = pg.from_("datasets").select("slug").order("slug", desc=True).execute()
+    assert [r["slug"] for r in res.data] == ["beta", "alpha"]
 
 
 def test_client_filter_eq(live_server, seeded, admin):

--- a/backend/ninja_postgrest/tests/test_postgrest_client.py
+++ b/backend/ninja_postgrest/tests/test_postgrest_client.py
@@ -125,14 +125,13 @@ def test_client_guardian_filtering(live_server, seeded):
 def test_client_insert_single(live_server, seeded, admin):
     pipeline = seeded
     pg = pg_client(live_server, admin)
-    pg.from_("datasets").insert(
-        {"slug": "gamma", "pipeline_id": pipeline.id, "state": "Active"},
-    ).execute()
-    # Verify the round-trip by reading the new row back through the client.
     res = (
-        pg.from_("datasets").select("slug,state").eq("slug", "gamma").single().execute()
+        pg.from_("datasets")
+        .insert({"slug": "gamma", "pipeline_id": pipeline.id, "state": "Active"})
+        .execute()
     )
-    assert res.data == {"slug": "gamma", "state": "Active"}
+    # A single-object body still comes back as an array, matching PostgREST.
+    assert [r["slug"] for r in res.data] == ["gamma"]
     assert Dataset.objects.filter(slug="gamma").exists()
 
 

--- a/backend/ninja_postgrest/tests/test_postgrest_client.py
+++ b/backend/ninja_postgrest/tests/test_postgrest_client.py
@@ -305,3 +305,85 @@ def test_client_delete_filtered_by_guardian(live_server, seeded, alice):
     assert [r["slug"] for r in res.data] == ["alpha"]
     assert not Dataset.objects.filter(slug="alpha").exists()
     assert Dataset.objects.filter(slug="beta").exists()
+
+
+# --------------------------------------------------------------------------- #
+# Coverage backfill (F-6): match/imatch, isdistinct, offset/range pagination,
+# nullsfirst/nullslast ordering, select alias, JSON-path serialization.
+# --------------------------------------------------------------------------- #
+def test_client_match_regex(live_server, seeded, admin):
+    pg = pg_client(live_server, admin)
+    res = pg.from_("datasets").select("slug").filter("slug", "match", "^al").execute()
+    assert [r["slug"] for r in res.data] == ["alpha"]
+
+
+def test_client_imatch_case_insensitive(live_server, seeded, admin):
+    pg = pg_client(live_server, admin)
+    res = pg.from_("datasets").select("slug").filter("slug", "imatch", "^AL").execute()
+    assert [r["slug"] for r in res.data] == ["alpha"]
+
+
+def test_client_isdistinct(live_server, seeded, admin):
+    # Non-NULL path end-to-end; NULL-safety is unit-tested (no registered
+    # table has a nullable filterable column).
+    pg = pg_client(live_server, admin)
+    res = (
+        pg.from_("datasets")
+        .select("slug")
+        .filter("slug", "isdistinct", "alpha")
+        .execute()
+    )
+    assert [r["slug"] for r in res.data] == ["beta"]
+
+
+def test_client_offset(live_server, seeded, admin):
+    pg = pg_client(live_server, admin)
+    res = pg.from_("datasets").select("slug").order("slug").limit(1).offset(1).execute()
+    assert [r["slug"] for r in res.data] == ["beta"]
+
+
+def test_client_range(live_server, seeded, admin):
+    pg = pg_client(live_server, admin)
+    res = pg.from_("datasets").select("slug").order("slug").range(0, 0).execute()
+    assert [r["slug"] for r in res.data] == ["alpha"]
+
+
+def test_client_order_nulls_modifiers(live_server, seeded, admin):
+    # No orderable column is nullable, so this exercises the
+    # nullsfirst/nullslast grammar end-to-end (parse -> ORM -> SQL) rather
+    # than NULL placement.
+    pg = pg_client(live_server, admin)
+    res = (
+        pg.from_("datasets")
+        .select("slug")
+        .order("slug", desc=True, nullsfirst=True)
+        .execute()
+    )
+    assert [r["slug"] for r in res.data] == ["beta", "alpha"]
+    res = pg.from_("datasets").select("slug").order("slug", nullsfirst=False).execute()
+    assert [r["slug"] for r in res.data] == ["alpha", "beta"]
+
+
+def test_client_select_alias(live_server, seeded, admin):
+    pg = pg_client(live_server, admin)
+    res = pg.from_("datasets").select("name:slug").order("slug").execute()
+    assert res.data[0] == {"name": "alpha"}
+
+
+def test_client_json_path_serialization(live_server, seeded, admin):
+    # config is a JSONField on dataset_configs; ->> renders via _dig_json.
+    cfg = DatasetConfig.objects.get()
+    cfg.config = {"units": "m", "nested": {"depth": 2}}
+    cfg.save()
+    pg = pg_client(live_server, admin)
+    res = pg.from_("dataset_configs").select("config->>units").single().execute()
+    assert res.data == {"units": "m"}
+    res = (
+        pg.from_("dataset_configs")
+        .select("depth:config->nested->>depth")
+        .single()
+        .execute()
+    )
+    # Characterizes current behavior: the raw JSON value (int). Real PostgREST
+    # casts ->> to text ("2") — divergence tracked as F-10 in Findings.md.
+    assert res.data == {"depth": 2}

--- a/backend/ninja_postgrest/tests/test_postgrest_client.py
+++ b/backend/ninja_postgrest/tests/test_postgrest_client.py
@@ -384,6 +384,8 @@ def test_client_json_path_serialization(live_server, seeded, admin):
         .single()
         .execute()
     )
-    # Characterizes current behavior: the raw JSON value (int). Real PostgREST
-    # casts ->> to text ("2") — divergence tracked as F-10 in Findings.md.
-    assert res.data == {"depth": 2}
+    # ->> extracts as text, matching PostgREST (F-10).
+    assert res.data == {"depth": "2"}
+    # -> (single arrow) extracts the raw JSON value.
+    res = pg.from_("dataset_configs").select("nested:config->nested").single().execute()
+    assert res.data == {"nested": {"depth": 2}}

--- a/backend/ninja_postgrest/tests/test_postgrest_client.py
+++ b/backend/ninja_postgrest/tests/test_postgrest_client.py
@@ -170,16 +170,27 @@ def test_client_delete(live_server, seeded, admin):
 
 
 def test_client_upsert_new_row(live_server, seeded, admin):
-    # Upsert of a *new* row behaves like an insert; the server ignores the
-    # ``Prefer: resolution`` header. Conflict-resolution (updating an existing
-    # row on a unique-key clash) is not implemented server-side, so this only
-    # exercises the no-conflict path.
+    # Without an on_conflict target an upsert degrades to a plain insert.
     pipeline = seeded
     pg = pg_client(live_server, admin)
     pg.from_("datasets").upsert(
         {"slug": "epsilon", "pipeline_id": pipeline.id},
     ).execute()
     assert Dataset.objects.filter(slug="epsilon").exists()
+
+
+def test_client_upsert_merge_on_conflict(live_server, seeded, admin):
+    # Upsert keyed on slug updates the existing "alpha" row rather than
+    # colliding with its unique slug.
+    pg = pg_client(live_server, admin)
+    res = (
+        pg.from_("datasets")
+        .upsert({"slug": "alpha", "state": "Disabled"}, on_conflict="slug")
+        .execute()
+    )
+    assert [r["slug"] for r in res.data] == ["alpha"]
+    assert Dataset.objects.filter(slug="alpha").count() == 1
+    assert Dataset.objects.get(slug="alpha").state == "Disabled"
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/ninja_postgrest/tests/test_postgrest_client.py
+++ b/backend/ninja_postgrest/tests/test_postgrest_client.py
@@ -250,7 +250,7 @@ def test_client_single_multiple_rows_raises_apierror(live_server, seeded, admin)
     with pytest.raises(APIError) as excinfo:
         pg.from_("datasets").select("slug").single().execute()
     err = excinfo.value
-    assert err.code == "PGRST-406"
+    assert err.code == "PGRST116"
     assert "exactly one row" in err.message
 
 

--- a/backend/ninja_postgrest/tests/test_postgrest_client.py
+++ b/backend/ninja_postgrest/tests/test_postgrest_client.py
@@ -14,6 +14,8 @@ postgrest = pytest.importorskip("postgrest")
 from postgrest import SyncPostgrestClient  # noqa: E402
 from postgrest.exceptions import APIError  # noqa: E402
 
+from guardian.shortcuts import assign_perm  # noqa: E402
+
 from datasets.models import Dataset, DatasetConfig  # noqa: E402
 from pipelines.models import Pipeline  # noqa: E402
 
@@ -40,6 +42,11 @@ def seeded():
 @pytest.fixture
 def admin():
     return User.objects.create_superuser("admin", password="pw")  # noqa: S106
+
+
+@pytest.fixture
+def alice():
+    return User.objects.create_user("alice", password="pw")  # noqa: S106
 
 
 def pg_client(live_server, user) -> SyncPostgrestClient:
@@ -254,3 +261,42 @@ def test_client_non_filterable_column_raises_apierror(live_server, seeded, admin
     err = excinfo.value
     assert err.code == "PGRST-400"
     assert "not filterable" in err.message
+
+
+# --------------------------------------------------------------------------- #
+# Write authorization through the client (guardian filtering on update/delete)
+# --------------------------------------------------------------------------- #
+def test_client_update_filtered_by_guardian(live_server, seeded, alice):
+    # alice may change alpha but not beta; an update matching both touches only
+    # the row she can change.
+    Dataset.objects.get(slug="alpha").assign_edit_permission(alice)
+    pg = pg_client(live_server, alice)
+    res = (
+        pg.from_("datasets")
+        .update({"state": "Disabled"})
+        .eq("state", "Active")
+        .execute()
+    )
+    assert [r["slug"] for r in res.data] == ["alpha"]
+    assert Dataset.objects.get(slug="alpha").state == "Disabled"
+    assert Dataset.objects.get(slug="beta").state == "Active"
+
+
+def test_client_update_without_perm_is_noop(live_server, seeded, alice):
+    pg = pg_client(live_server, alice)
+    res = (
+        pg.from_("datasets").update({"state": "Disabled"}).eq("slug", "alpha").execute()
+    )
+    assert res.data == []
+    assert Dataset.objects.get(slug="alpha").state == "Active"
+
+
+def test_client_delete_filtered_by_guardian(live_server, seeded, alice):
+    # alice may delete alpha but not beta; a delete matching both removes only
+    # the row she can delete.
+    assign_perm("datasets.delete_dataset", alice, Dataset.objects.get(slug="alpha"))
+    pg = pg_client(live_server, alice)
+    res = pg.from_("datasets").delete().in_("slug", ["alpha", "beta"]).execute()
+    assert [r["slug"] for r in res.data] == ["alpha"]
+    assert not Dataset.objects.filter(slug="alpha").exists()
+    assert Dataset.objects.filter(slug="beta").exists()

--- a/backend/ninja_postgrest/views.py
+++ b/backend/ninja_postgrest/views.py
@@ -1,0 +1,205 @@
+"""Generic PostgREST view factories, one set per registered table."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from django.core.serializers.json import DjangoJSONEncoder
+from django.db import transaction
+from django.db.models import Model
+from django.http import HttpRequest, HttpResponse, JsonResponse
+
+from .conf import get_global_config
+from .exceptions import PostgrestError, postgrest_endpoint
+from .headers import content_range, parse_prefer, wants_single_object
+from .parsing import parse_request
+from .permissions import filter_writable, require_create
+from .query import build_read_queryset, slice_queryset
+from .registry import TableConfig
+from .serialization import serialize_instance
+
+
+def _user(request: HttpRequest):
+    return getattr(request, "user", None)
+
+
+def _json_response(data: Any, *, status: int = 200) -> JsonResponse:
+    return JsonResponse(
+        data,
+        status=status,
+        safe=not isinstance(data, list),
+        encoder=DjangoJSONEncoder,
+    )
+
+
+def _load_body(request: HttpRequest) -> Any:
+    if not request.body:
+        return None
+    try:
+        return json.loads(request.body)
+    except json.JSONDecodeError as exc:
+        raise PostgrestError(
+            f"Invalid JSON body: {exc}",
+            status=400,
+            code="PGRST-400",
+        ) from exc
+
+
+def _writable_keys(table: TableConfig) -> dict[str, str]:
+    """Map every accepted request key to the model attribute to set.
+
+    Accepts both the field name (``pipeline``) and, for relations, the column
+    name (``pipeline_id``).
+    """
+    mapping: dict[str, str] = {}
+    for fname in table.writable:
+        field = table.model._meta.get_field(fname)
+        if field.is_relation and (field.many_to_one or field.one_to_one):
+            mapping[field.attname] = field.attname  # pipeline_id
+            mapping[field.name] = field.attname  # pipeline -> pipeline_id
+        else:
+            mapping[field.name] = field.name
+    return mapping
+
+
+def _apply_data(obj: Model, table: TableConfig, data: dict[str, Any]) -> None:
+    allowed = _writable_keys(table)
+    for key, value in data.items():
+        if key not in allowed:
+            raise PostgrestError(
+                f"Column {key!r} is not writable on table {table.name!r}",
+                status=400,
+                code="PGRST-400",
+                hint=f"Writable columns: {sorted(set(allowed))}",
+            )
+        setattr(obj, allowed[key], value)
+
+
+# --------------------------------------------------------------------------- #
+# GET (list / single)
+# --------------------------------------------------------------------------- #
+def make_list_view(table: TableConfig) -> Callable:
+    @postgrest_endpoint
+    def view(request: HttpRequest):
+        gc = get_global_config()
+        parsed = parse_request(request, table)
+        prefer = parse_prefer(request)
+        qs = build_read_queryset(table, parsed, _user(request))
+
+        total = qs.count() if prefer.count == "exact" else None
+        page = slice_queryset(qs, parsed.offset, parsed.limit, gc.max_limit)
+        rows = [serialize_instance(obj, table, parsed.select) for obj in page]
+
+        if wants_single_object(request):
+            if len(rows) != 1:
+                raise PostgrestError(
+                    "JSON object requested, but query did not return exactly one row",
+                    status=406,
+                    details=f"Results contain {len(rows)} rows",
+                    code="PGRST-406",
+                )
+            return _json_response(rows[0])
+
+        resp = _json_response(rows)
+        resp["Content-Range"] = content_range(parsed.offset, len(rows), total)
+        return resp
+
+    view.__name__ = f"list_{table.name}"
+    return view
+
+
+# --------------------------------------------------------------------------- #
+# POST (create)
+# --------------------------------------------------------------------------- #
+def make_create_view(table: TableConfig) -> Callable:
+    @postgrest_endpoint
+    def view(request: HttpRequest):
+        require_create(_user(request), table)
+        prefer = parse_prefer(request)
+        payload = _load_body(request)
+        is_bulk = isinstance(payload, list)
+        items = payload if is_bulk else [payload]
+
+        created: list[Model] = []
+        with transaction.atomic():
+            for data in items:
+                if not isinstance(data, dict):
+                    raise PostgrestError("Each row must be a JSON object", status=400)
+                obj = table.model()
+                _apply_data(obj, table, data)
+                obj.save()
+                created.append(obj)
+
+        if not prefer.return_representation:
+            return HttpResponse(status=201)
+        rows = [serialize_instance(obj, table, None) for obj in created]
+        return _json_response(rows if is_bulk else rows[0], status=201)
+
+    view.__name__ = f"create_{table.name}"
+    return view
+
+
+# --------------------------------------------------------------------------- #
+# PATCH (update)
+# --------------------------------------------------------------------------- #
+def make_update_view(table: TableConfig) -> Callable:
+    @postgrest_endpoint
+    def view(request: HttpRequest):
+        prefer = parse_prefer(request)
+        parsed = parse_request(request, table)
+        data = _load_body(request)
+        if not isinstance(data, dict):
+            raise PostgrestError("PATCH body must be a JSON object", status=400)
+
+        qs = table.model._default_manager.all().filter(parsed.q)
+        qs = filter_writable(_user(request), table, qs, "update")
+
+        updated: list[Model] = []
+        with transaction.atomic():
+            for obj in qs.select_for_update():
+                _apply_data(obj, table, data)
+                obj.save()
+                updated.append(obj)
+
+        if not prefer.return_representation:
+            return HttpResponse(status=204)
+        rows = [serialize_instance(obj, table, parsed.select) for obj in updated]
+        return _json_response(rows)
+
+    view.__name__ = f"update_{table.name}"
+    return view
+
+
+# --------------------------------------------------------------------------- #
+# DELETE
+# --------------------------------------------------------------------------- #
+def make_delete_view(table: TableConfig) -> Callable:
+    @postgrest_endpoint
+    def view(request: HttpRequest):
+        prefer = parse_prefer(request)
+        parsed = parse_request(request, table)
+
+        qs = table.model._default_manager.all().filter(parsed.q)
+        qs = filter_writable(_user(request), table, qs, "delete")
+
+        rows = None
+        if prefer.return_representation:
+            rows = [serialize_instance(obj, table, parsed.select) for obj in qs]
+        qs.delete()
+
+        if rows is None:
+            return HttpResponse(status=204)
+        return _json_response(rows)
+
+    view.__name__ = f"delete_{table.name}"
+    return view
+
+
+__all__ = [
+    "make_create_view",
+    "make_delete_view",
+    "make_list_view",
+    "make_update_view",
+]

--- a/backend/ninja_postgrest/views.py
+++ b/backend/ninja_postgrest/views.py
@@ -185,7 +185,13 @@ def make_list_view(table: TableConfig) -> Callable:
         qs = build_read_queryset(table, parsed, _user(request))
 
         total = qs.count() if prefer.count == "exact" else None
-        page = slice_queryset(qs, parsed.offset, parsed.limit, gc.max_limit)
+        page = slice_queryset(
+            qs,
+            parsed.offset,
+            parsed.limit,
+            gc.max_limit,
+            gc.default_limit,
+        )
         rows = [serialize_instance(obj, table, parsed.select) for obj in page]
 
         if wants_single_object(request):

--- a/backend/ninja_postgrest/views.py
+++ b/backend/ninja_postgrest/views.py
@@ -120,6 +120,33 @@ def _conflict_attnames(request: HttpRequest, table: TableConfig) -> list[str]:
     ]
 
 
+def _insert_columns(request: HttpRequest, table: TableConfig) -> set[str] | None:
+    """Parse ``?columns=a,b`` into the set of body keys to keep on insert.
+
+    Returns ``None`` when unspecified (no restriction). Each listed column must
+    be a writable key; an unknown/non-writable column is a 400 (you cannot
+    insert a column you may not write).
+    """
+    raw = request.GET.get("columns", "").strip()
+    if not raw:
+        return None
+    allowed = _writable_keys(table)
+    cols: set[str] = set()
+    for tok in raw.split(","):
+        tok = tok.strip().strip("'\"")
+        if not tok:
+            continue
+        if tok not in allowed:
+            raise PostgrestError(
+                f"Column {tok!r} in 'columns' is not writable on table {table.name!r}",
+                status=400,
+                code="PGRST-400",
+                hint=f"Writable columns: {sorted(set(allowed))}",
+            )
+        cols.add(tok)
+    return cols
+
+
 def _upsert_rows(
     user,
     table: TableConfig,
@@ -219,6 +246,10 @@ def make_create_view(table: TableConfig) -> Callable:
         for data in items:
             if not isinstance(data, dict):
                 raise PostgrestError("Each row must be a JSON object", status=400)
+
+        columns = _insert_columns(request, table)
+        if columns is not None:
+            items = [{k: v for k, v in data.items() if k in columns} for data in items]
 
         # An upsert (Prefer: resolution=...) needs an on_conflict target to key
         # on; without one it degrades to a plain insert, mirroring PostgREST

--- a/backend/ninja_postgrest/views.py
+++ b/backend/ninja_postgrest/views.py
@@ -6,6 +6,7 @@ import json
 from collections.abc import Callable
 from typing import Any
 
+from django.core.exceptions import FieldDoesNotExist
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import transaction
 from django.db.models import Model
@@ -93,6 +94,77 @@ def _single_object_or_406(rows: list) -> Any:
     return rows[0]
 
 
+def _column_attname(table: TableConfig, token: str) -> str:
+    """Resolve an ``on_conflict`` token (field name or column name) to an attname."""
+    try:
+        return table.model._meta.get_field(token).attname
+    except FieldDoesNotExist:
+        pass
+    for f in table.model._meta.get_fields():
+        if getattr(f, "attname", None) == token:
+            return token
+    raise PostgrestError(
+        f"Unknown on_conflict column {token!r} on table {table.name!r}",
+        status=400,
+        code="PGRST-400",
+    )
+
+
+def _conflict_attnames(request: HttpRequest, table: TableConfig) -> list[str]:
+    """The ``on_conflict`` columns as attnames, or ``[]`` when unspecified."""
+    raw = request.GET.get("on_conflict", "").strip()
+    if not raw:
+        return []
+    return [
+        _column_attname(table, tok.strip()) for tok in raw.split(",") if tok.strip()
+    ]
+
+
+def _upsert_rows(
+    table: TableConfig,
+    items: list,
+    conflict: list[str],
+    resolution: str,
+) -> list[Model]:
+    """Insert-or-update each row, keyed on the ``on_conflict`` columns.
+
+    ``merge-duplicates`` updates the conflicting row from the remaining body
+    columns; ``ignore-duplicates`` leaves an existing row untouched. Uses
+    ``update_or_create`` / ``get_or_create`` so the behaviour is identical on
+    every backend and real instances are returned for the representation.
+    """
+    allowed = _writable_keys(table)
+    manager = table.model._default_manager
+    ignore = resolution == "ignore-duplicates"
+    out: list[Model] = []
+    for data in items:
+        lookup: dict[str, Any] = {}
+        defaults: dict[str, Any] = {}
+        for key, value in data.items():
+            if key not in allowed:
+                raise PostgrestError(
+                    f"Column {key!r} is not writable on table {table.name!r}",
+                    status=400,
+                    code="PGRST-400",
+                    hint=f"Writable columns: {sorted(set(allowed))}",
+                )
+            target = lookup if allowed[key] in conflict else defaults
+            target[allowed[key]] = value
+        missing = [c for c in conflict if c not in lookup]
+        if missing:
+            raise PostgrestError(
+                f"on_conflict column(s) {missing} missing from row",
+                status=400,
+                code="PGRST-400",
+            )
+        if ignore:
+            obj, _ = manager.get_or_create(defaults=defaults, **lookup)
+        else:
+            obj, _ = manager.update_or_create(defaults=defaults, **lookup)
+        out.append(obj)
+    return out
+
+
 # --------------------------------------------------------------------------- #
 # GET (list / single)
 # --------------------------------------------------------------------------- #
@@ -130,16 +202,24 @@ def make_create_view(table: TableConfig) -> Callable:
         payload = _load_body(request)
         is_bulk = isinstance(payload, list)
         items = payload if is_bulk else [payload]
+        for data in items:
+            if not isinstance(data, dict):
+                raise PostgrestError("Each row must be a JSON object", status=400)
 
+        # An upsert (Prefer: resolution=...) needs an on_conflict target to key
+        # on; without one it degrades to a plain insert, mirroring PostgREST
+        # when no conflict target can be inferred.
+        conflict = _conflict_attnames(request, table) if prefer.resolution else []
         created: list[Model] = []
         with transaction.atomic():
-            for data in items:
-                if not isinstance(data, dict):
-                    raise PostgrestError("Each row must be a JSON object", status=400)
-                obj = table.model()
-                _apply_data(obj, table, data)
-                obj.save()
-                created.append(obj)
+            if conflict:
+                created = _upsert_rows(table, items, conflict, prefer.resolution)
+            else:
+                for data in items:
+                    obj = table.model()
+                    _apply_data(obj, table, data)
+                    obj.save()
+                    created.append(obj)
 
         if not prefer.return_representation:
             return HttpResponse(status=201)

--- a/backend/ninja_postgrest/views.py
+++ b/backend/ninja_postgrest/views.py
@@ -77,6 +77,22 @@ def _apply_data(obj: Model, table: TableConfig, data: dict[str, Any]) -> None:
         setattr(obj, allowed[key], value)
 
 
+def _single_object_or_406(rows: list) -> Any:
+    """Return the sole row for a singular response, or raise 406.
+
+    Mirrors PostgREST: ``Accept: application/vnd.pgrst.object+json`` demands
+    exactly one row.
+    """
+    if len(rows) != 1:
+        raise PostgrestError(
+            "JSON object requested, but query did not return exactly one row",
+            status=406,
+            details=f"Results contain {len(rows)} rows",
+            code="PGRST-406",
+        )
+    return rows[0]
+
+
 # --------------------------------------------------------------------------- #
 # GET (list / single)
 # --------------------------------------------------------------------------- #
@@ -93,14 +109,7 @@ def make_list_view(table: TableConfig) -> Callable:
         rows = [serialize_instance(obj, table, parsed.select) for obj in page]
 
         if wants_single_object(request):
-            if len(rows) != 1:
-                raise PostgrestError(
-                    "JSON object requested, but query did not return exactly one row",
-                    status=406,
-                    details=f"Results contain {len(rows)} rows",
-                    code="PGRST-406",
-                )
-            return _json_response(rows[0])
+            return _json_response(_single_object_or_406(rows))
 
         resp = _json_response(rows)
         resp["Content-Range"] = content_range(parsed.offset, len(rows), total)
@@ -134,8 +143,12 @@ def make_create_view(table: TableConfig) -> Callable:
 
         if not prefer.return_representation:
             return HttpResponse(status=201)
+        # PostgREST returns an array whether one row or many were inserted; the
+        # singular media type (Accept) collapses it to one object.
         rows = [serialize_instance(obj, table, None) for obj in created]
-        return _json_response(rows if is_bulk else rows[0], status=201)
+        if wants_single_object(request):
+            return _json_response(_single_object_or_406(rows), status=201)
+        return _json_response(rows, status=201)
 
     view.__name__ = f"create_{table.name}"
     return view

--- a/backend/ninja_postgrest/views.py
+++ b/backend/ninja_postgrest/views.py
@@ -16,7 +16,7 @@ from .conf import get_global_config
 from .exceptions import PostgrestError, postgrest_endpoint
 from .headers import content_range, parse_prefer, wants_single_object
 from .parsing import parse_request
-from .permissions import filter_writable, require_create
+from .permissions import filter_writable, require_change_object, require_create
 from .query import build_read_queryset, slice_queryset
 from .registry import TableConfig
 from .serialization import serialize_instance
@@ -121,6 +121,7 @@ def _conflict_attnames(request: HttpRequest, table: TableConfig) -> list[str]:
 
 
 def _upsert_rows(
+    user,
     table: TableConfig,
     items: list,
     conflict: list[str],
@@ -132,6 +133,10 @@ def _upsert_rows(
     columns; ``ignore-duplicates`` leaves an existing row untouched. Uses
     ``update_or_create`` / ``get_or_create`` so the behaviour is identical on
     every backend and real instances are returned for the representation.
+
+    Inserting is gated by ``require_create`` (the model-level ``add`` perm) at
+    the view; updating an existing row additionally requires ``change`` on that
+    row, so ``add``-only callers cannot mutate rows they may not change.
     """
     allowed = _writable_keys(table)
     manager = table.model._default_manager
@@ -160,6 +165,9 @@ def _upsert_rows(
         if ignore:
             obj, _ = manager.get_or_create(defaults=defaults, **lookup)
         else:
+            existing = manager.filter(**lookup).first()
+            if existing is not None:
+                require_change_object(user, table, existing)
             obj, _ = manager.update_or_create(defaults=defaults, **lookup)
         out.append(obj)
     return out
@@ -213,7 +221,13 @@ def make_create_view(table: TableConfig) -> Callable:
         created: list[Model] = []
         with transaction.atomic():
             if conflict:
-                created = _upsert_rows(table, items, conflict, prefer.resolution)
+                created = _upsert_rows(
+                    _user(request),
+                    table,
+                    items,
+                    conflict,
+                    prefer.resolution,
+                )
             else:
                 for data in items:
                     obj = table.model()

--- a/backend/ninja_postgrest/views.py
+++ b/backend/ninja_postgrest/views.py
@@ -89,7 +89,7 @@ def _single_object_or_406(rows: list) -> Any:
             "JSON object requested, but query did not return exactly one row",
             status=406,
             details=f"Results contain {len(rows)} rows",
-            code="PGRST-406",
+            code="PGRST116",
         )
     return rows[0]
 

--- a/backend/ninja_postgrest/views.py
+++ b/backend/ninja_postgrest/views.py
@@ -94,6 +94,24 @@ def _single_object_or_406(rows: list) -> Any:
     return rows[0]
 
 
+def _location(
+    request: HttpRequest,
+    table: TableConfig,
+    created: list[Model],
+) -> str | None:
+    """PostgREST-style Location header for created rows: the request path plus a
+    PK filter (``?id=eq.5`` for one row, ``?id=in.(1,2)`` for several)."""
+    if not created:
+        return None
+    col = table.pk
+    values = [getattr(obj, col) for obj in created]
+    if len(values) == 1:
+        filt = f"{col}=eq.{values[0]}"
+    else:
+        filt = f"{col}=in.({','.join(str(v) for v in values)})"
+    return f"{request.path}?{filt}"
+
+
 def _column_attname(table: TableConfig, token: str) -> str:
     """Resolve an ``on_conflict`` token (field name or column name) to an attname."""
     try:
@@ -273,13 +291,19 @@ def make_create_view(table: TableConfig) -> Callable:
                     created.append(obj)
 
         if not prefer.return_representation:
-            return HttpResponse(status=201)
-        # PostgREST returns an array whether one row or many were inserted; the
-        # singular media type (Accept) collapses it to one object.
-        rows = [serialize_instance(obj, table, None) for obj in created]
-        if wants_single_object(request):
-            return _json_response(_single_object_or_406(rows), status=201)
-        return _json_response(rows, status=201)
+            resp = HttpResponse(status=201)
+        else:
+            # PostgREST returns an array whether one row or many were inserted;
+            # the singular media type (Accept) collapses it to one object.
+            rows = [serialize_instance(obj, table, None) for obj in created]
+            if wants_single_object(request):
+                resp = _json_response(_single_object_or_406(rows), status=201)
+            else:
+                resp = _json_response(rows, status=201)
+        location = _location(request, table, created)
+        if location:
+            resp["Location"] = location
+        return resp
 
     view.__name__ = f"create_{table.name}"
     return view
@@ -306,10 +330,16 @@ def make_update_view(table: TableConfig) -> Callable:
                 _apply_data(obj, table, data)
                 obj.save()
                 updated.append(obj)
+            # Singular representation must affect exactly one row; validate
+            # inside the tx so a 406 rolls the update back.
+            if prefer.return_representation and wants_single_object(request):
+                _single_object_or_406(updated)
 
         if not prefer.return_representation:
             return HttpResponse(status=204)
         rows = [serialize_instance(obj, table, parsed.select) for obj in updated]
+        if wants_single_object(request):
+            return _json_response(rows[0])
         return _json_response(rows)
 
     view.__name__ = f"update_{table.name}"
@@ -330,11 +360,16 @@ def make_delete_view(table: TableConfig) -> Callable:
 
         rows = None
         if prefer.return_representation:
-            rows = [serialize_instance(obj, table, parsed.select) for obj in qs]
+            objs = list(qs)
+            if wants_single_object(request):
+                _single_object_or_406(objs)  # 406 unless exactly one, before delete
+            rows = [serialize_instance(obj, table, parsed.select) for obj in objs]
         qs.delete()
 
         if rows is None:
             return HttpResponse(status=204)
+        if wants_single_object(request):
+            return _json_response(rows[0])
         return _json_response(rows)
 
     view.__name__ = f"delete_{table.name}"

--- a/backend/ninja_postgrest/views.py
+++ b/backend/ninja_postgrest/views.py
@@ -290,6 +290,11 @@ def make_create_view(table: TableConfig) -> Callable:
                     obj.save()
                     created.append(obj)
 
+            # Singular representation must affect exactly one row; validate
+            # inside the tx so a 406 rolls the insert back.
+            if prefer.return_representation and wants_single_object(request):
+                _single_object_or_406(created)
+
         if not prefer.return_representation:
             resp = HttpResponse(status=201)
         else:

--- a/backend/pixi.lock
+++ b/backend/pixi.lock
@@ -251,6 +251,8 @@ environments:
   dev:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
     options:
       pypi-prerelease-mode: if-necessary-or-explicit
     packages:
@@ -444,6 +446,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - pypi: https://files.pythonhosted.org/packages/ba/16/9826f089383c593cdfc4a6e5aca94d9e91ae1692c57af82c3b2aa5e810f7/anyio-4.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b0/73/6e1b01cbeb458807aa0831742232dbdd1fa92bfa33f52a3f176b4ff3dc11/multidict-6.7.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ea/3e/41909586cb148db0259e0208310067afda4cc097f4c7a779e829c1e68c46/postgrest-2.31.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8b/c6/979176efdaa3d239e36d503d5af63a0a773b36662ed8f52e5b6a6d9fd40e/propcache-0.5.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/df/88/09c28dad91e662ccfaa1b78f1c57badde74fc9d0b23e74aef644750ecd73/yarl-1.24.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -515,6 +526,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
+      - pypi: https://files.pythonhosted.org/packages/ba/16/9826f089383c593cdfc4a6e5aca94d9e91ae1692c57af82c3b2aa5e810f7/anyio-4.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/ea/3e/41909586cb148db0259e0208310067afda4cc097f4c7a779e829c1e68c46/postgrest-2.31.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/70/06/2f46c318e3307cd7a6a7481def374ce838c0fe20084b39dd54b0879d0e99/propcache-0.5.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/02/a7/45baabfff76829264e623b185cff0c340d7e11bf3e1cd9ea37e7d17934bd/yarl-1.24.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -598,6 +619,16 @@ packages:
   - pkg:pypi/annotated-types?source=hash-mapping
   size: 18074
   timestamp: 1733247158254
+- pypi: https://files.pythonhosted.org/packages/ba/16/9826f089383c593cdfc4a6e5aca94d9e91ae1692c57af82c3b2aa5e810f7/anyio-4.14.0-py3-none-any.whl
+  name: anyio
+  version: 4.14.0
+  sha256: dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9
+  requires_dist:
+  - exceptiongroup>=1.0.2 ; python_full_version < '3.11'
+  - idna>=2.8
+  - typing-extensions>=4.5 ; python_full_version < '3.13'
+  - trio>=0.32.0 ; extra == 'trio'
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyhd8ed1ab_1.conda
   sha256: 5b9ef6d338525b332e17c3ed089ca2f53a5d74b7a7b432747d29c6466e39346d
   md5: f4e90937bbfc3a4a92539545a37bb448
@@ -1137,6 +1168,12 @@ packages:
   license_family: GPL
   size: 437860
   timestamp: 1747855126005
+- pypi: https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl
+  name: deprecation
+  version: 2.1.0
+  sha256: a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a
+  requires_dist:
+  - packaging
 - conda: https://conda.anaconda.org/conda-forge/noarch/django-5.2.14-pyhd8ed1ab_0.conda
   sha256: e5501e81fd82da2f8be6b102374dd305e277eac9b43cf373456d0357a546947f
   md5: 538641f69d545d93175cec69b823903a
@@ -1728,6 +1765,11 @@ packages:
   license_family: GPL
   size: 130050
   timestamp: 1772241472852
+- pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
+  name: h11
+  version: 0.16.0
+  sha256: 63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
+  requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
   sha256: 84c64443368f84b600bfecc529a1194a3b14c3656ee2e832d15a20e0329b6da3
   md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
@@ -1801,6 +1843,36 @@ packages:
   license_family: MIT
   size: 30731
   timestamp: 1737618390337
+- pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
+  name: httpcore
+  version: 1.0.9
+  sha256: 2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55
+  requires_dist:
+  - certifi
+  - h11>=0.16
+  - anyio>=4.0,<5.0 ; extra == 'asyncio'
+  - h2>=3,<5 ; extra == 'http2'
+  - socksio==1.* ; extra == 'socks'
+  - trio>=0.22.0,<1.0 ; extra == 'trio'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
+  name: httpx
+  version: 0.28.1
+  sha256: d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
+  requires_dist:
+  - anyio
+  - certifi
+  - httpcore==1.*
+  - idna
+  - brotli ; platform_python_implementation == 'CPython' and extra == 'brotli'
+  - brotlicffi ; platform_python_implementation != 'CPython' and extra == 'brotli'
+  - click==8.* ; extra == 'cli'
+  - pygments==2.* ; extra == 'cli'
+  - rich>=10,<14 ; extra == 'cli'
+  - h2>=3,<5 ; extra == 'http2'
+  - socksio==1.* ; extra == 'socks'
+  - zstandard>=0.18.0 ; extra == 'zstd'
+  requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
   sha256: 77af6f5fe8b62ca07d09ac60127a30d9069fdc3c68d6b256754d0ffb1f7779f8
   md5: 8e6923fc12f1fe8f8c4e5c9f343256ac
@@ -1852,6 +1924,15 @@ packages:
   license_family: MIT
   size: 12837286
   timestamp: 1773822650615
+- pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
+  name: idna
+  version: '3.18'
+  sha256: 7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2
+  requires_dist:
+  - ruff>=0.6.2 ; extra == 'all'
+  - mypy>=1.11.2 ; extra == 'all'
+  - pytest>=8.3.2 ; extra == 'all'
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
   sha256: ae89d0299ada2a3162c2614a9d26557a92aa6a77120ce142f8e0109bbf0342b0
   md5: 53abe63df7e10a6ba605dc5f9f961d36
@@ -3507,6 +3588,20 @@ packages:
   license_family: PSF
   size: 8303180
   timestamp: 1777000576435
+- pypi: https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+  name: multidict
+  version: 6.7.1
+  sha256: 97231140a50f5d447d3164f994b86a0bed7cd016e2682f8650d6a9158e14fd31
+  requires_dist:
+  - typing-extensions>=4.1.0 ; python_full_version < '3.11'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/b0/73/6e1b01cbeb458807aa0831742232dbdd1fa92bfa33f52a3f176b4ff3dc11/multidict-6.7.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: multidict
+  version: 6.7.1
+  sha256: 9d624335fd4fa1c08a53f8b4be7676ebde19cd092b3895c421045ca87895b429
+  requires_dist:
+  - typing-extensions>=4.1.0 ; python_full_version < '3.11'
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
   sha256: d09c47c2cf456de5c09fa66d2c3c5035aa1fa228a1983a433c47b876aa16ce90
   md5: 37293a85a0f4f77bbd9cf7aaefc62609
@@ -3898,6 +3993,48 @@ packages:
   license_family: MIT
   size: 25877
   timestamp: 1764896838868
+- pypi: https://files.pythonhosted.org/packages/ea/3e/41909586cb148db0259e0208310067afda4cc097f4c7a779e829c1e68c46/postgrest-2.31.0-py3-none-any.whl
+  name: postgrest
+  version: 2.31.0
+  sha256: c2fd47c94e13ee8335111c4f03c9a24ea9766ce9d35fc3cd7330057c9e7ea0c3
+  requires_dist:
+  - httpx[http2]>=0.26,<0.29
+  - deprecation>=2.1.0
+  - pydantic>=1.9,<3.0
+  - strenum>=0.4.9 ; python_full_version < '3.11'
+  - yarl>=1.20.1
+  requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+  md5: edb16f14d920fb3faf17f5ce582942d6
+  depends:
+  - python >=3.10
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.52
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 273927
+  timestamp: 1756321848365
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
+  sha256: e79922a360d7e620df978417dd033e66226e809961c3e659a193f978a75a9b0b
+  md5: 6d034d3a6093adbba7b24cb69c8c621e
+  depends:
+  - prompt-toolkit >=3.0.52,<3.0.53.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7212
+  timestamp: 1756321849562
+- pypi: https://files.pythonhosted.org/packages/70/06/2f46c318e3307cd7a6a7481def374ce838c0fe20084b39dd54b0879d0e99/propcache-0.5.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+  name: propcache
+  version: 0.5.2
+  sha256: ba57fffe4ac99c5d30076161b5866336d97600769bad35cc68f7774b15298a4e
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/8b/c6/979176efdaa3d239e36d503d5af63a0a773b36662ed8f52e5b6a6d9fd40e/propcache-0.5.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: propcache
+  version: 0.5.2
+  sha256: 4db0ba63d693afd40d249bd93f842b5f144f8fcbb83de05660373bcf30517b1d
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.1.0-py313h07c4f96_0.conda
   sha256: 6058abf3d6b8ca24fbbe16b56f5a333f7ef55475d3e59ce3ad6f20e46ca49102
   md5: f25cdf145885936fe458452d73d991dc
@@ -5092,6 +5229,24 @@ packages:
   license_family: MIT
   size: 570010
   timestamp: 1766154256151
+- pypi: https://files.pythonhosted.org/packages/02/a7/45baabfff76829264e623b185cff0c340d7e11bf3e1cd9ea37e7d17934bd/yarl-1.24.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+  name: yarl
+  version: 1.24.2
+  sha256: fecd17873a096036c1c87ab3486f1aef7f269ada7f23f7f856f93b1cc7744f14
+  requires_dist:
+  - idna>=2.0
+  - multidict>=4.0
+  - propcache>=0.2.1
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/df/88/09c28dad91e662ccfaa1b78f1c57badde74fc9d0b23e74aef644750ecd73/yarl-1.24.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: yarl
+  version: 1.24.2
+  sha256: 91e72cf093fd833483a97ee648e0c053c7c629f51ff4a0e7edd84f806b0c5617
+  requires_dist:
+  - idna>=2.0
+  - multidict>=4.0
+  - propcache>=0.2.1
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
   sha256: b4533f7d9efc976511a73ef7d4a2473406d7f4c750884be8e8620b0ce70f4dae
   md5: 30cd29cb87d819caead4d55184c1d115

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -57,6 +57,11 @@ pytest-django = "*"
 pytest-cov = ">=7.1.0,<8"
 pytest-env = ">=1.6.0,<2"
 
+[tool.pixi.feature.dev.pypi-dependencies]
+# Standard PostgREST client, used to validate the ninja_postgrest endpoints
+# against a real client library in the integration tests.
+postgrest = "*"
+
 [tool.pixi.environments]
 dev = [ "dev" ]
 


### PR DESCRIPTION
This is an attempt to make a reusable Django app that can serve PostgREST compatible endpoints for specified models.

The models are configured in `settings.py` with with per model permissions levels and handlers, using Django user permissions (via Guardian, without them needing to be synced to row level permissions). 

[Docs](https://github.com/ioos/buoy_retriever/blob/dj-postgrest/backend/ninja_postgrest/README.md)

Mostly written by Claude under supervision. Claude also wrote the tests and I pushed it to extend into other test cases, and has tested with [`postgrest`](https://pypi.org/project/postgrest/) Python client.