### PR TITLE
Codecov needs to inhert secrets

### DIFF
--- a/.github/workflows/pipeline_aveva.yml
+++ b/.github/workflows/pipeline_aveva.yml
@@ -7,10 +7,16 @@ on:
         paths:
             - common/**
             - pipeline/aveva/**
+            - .github/workflows/_shortsha.yml
+            - .github/workflows/_build_image.yml
+            - .github/workflows/pipeline_aveva.yml
     pull_request:
         paths:
             - common/**
             - pipeline/aveva/**
+            - .github/workflows/_shortsha.yml
+            - .github/workflows/_build_image.yml
+            - .github/workflows/pipeline_aveva.yml
     workflow_dispatch:
 
 jobs:
@@ -20,6 +26,7 @@ jobs:
     build_test_push:
         needs: [shortsha]
         uses: ./.github/workflows/_build_image.yml
+        secrets: inherit
         with:
             working_directory: ./pipeline/aveva
             image_name: buoy_retriever_aveva

--- a/.github/workflows/pipeline_hohonu.yml
+++ b/.github/workflows/pipeline_hohonu.yml
@@ -7,10 +7,16 @@ on:
         paths:
             - common/**
             - pipeline/hohonu/**
+            - .github/workflows/_shortsha.yml
+            - .github/workflows/_build_image.yml
+            - .github/workflows/pipeline_hohonu.yml
     pull_request:
         paths:
             - common/**
             - pipeline/hohonu/**
+            - .github/workflows/_shortsha.yml
+            - .github/workflows/_build_image.yml
+            - .github/workflows/pipeline_hohonu.yml
     workflow_dispatch:
 
 jobs:
@@ -20,6 +26,7 @@ jobs:
     build_test_push:
         needs: [shortsha]
         uses: ./.github/workflows/_build_image.yml
+        secrets: inherit
         with:
             working_directory: ./pipeline/hohonu
             image_name: buoy_retriever_hohonu

--- a/.github/workflows/pipeline_s3_timeseries.yml
+++ b/.github/workflows/pipeline_s3_timeseries.yml
@@ -7,10 +7,16 @@ on:
         paths:
             - common/**
             - pipeline/s3_timeseries/**
+            - .github/workflows/_shortsha.yml
+            - .github/workflows/_build_image.yml
+            - .github/workflows/pipeline_s3_timeseries.yml
     pull_request:
         paths:
             - common/**
             - pipeline/s3_timeseries/**
+            - .github/workflows/_shortsha.yml
+            - .github/workflows/_build_image.yml
+            - .github/workflows/pipeline_s3_timeseries.yml
     workflow_dispatch:
 
 jobs:
@@ -20,6 +26,7 @@ jobs:
     build_test_push:
         needs: [shortsha]
         uses: ./.github/workflows/_build_image.yml
+        secrets: inherit
         with:
             working_directory: ./pipeline/s3_timeseries
             image_name: buoy_retriever_s3_timeseries


### PR DESCRIPTION
While the codecov secret is defined at the repo level, we need to explicitly say that that the underlying `workflow_call` is allowed to use the secrets defined in the repo.

This also tweaks the pipelines to run whenever their workflows are changed as well.