### PR TITLE
Replace deprecated codecov/test-results-action

### DIFF
--- a/.github/workflows/_build_image.yml
+++ b/.github/workflows/_build_image.yml
@@ -244,9 +244,11 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && inputs.test_command && inputs.upload_tests }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
 
       - name: Clean up test container
         if: ${{ inputs.test_command }}


### PR DESCRIPTION
Replaces `codecov/test-report-action` with `codecov/codecov-action` with the right arguments, so we’re not getting message like this in actions that might eventually break:

```
Run codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3
Warning: This action is being deprecated in favor of 'codecov-action'.
      Please update CI accordingly to use 'codecov-action@v5' with
      'report_type: test_results'.
      The 'codecov-action' should and can be run at least once for
      coverage and once for test results

```
From: 
https://github.com/ioos/buoy_retriever/actions/runs/29863688661/job/88746508581#step:15:14